### PR TITLE
Bump monitoring component versions

### DIFF
--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -73,7 +73,7 @@ fi
 
 # Check if Prometheus Operator CRDs are already installed
 PROM_OPERATOR_CRD_UPDATE=${PROM_OPERATOR_CRD_UPDATE:-true}
-PROM_OPERATOR_CRD_VERSION=${PROM_OPERATOR_CRD_VERSION:-v0.43.2}
+PROM_OPERATOR_CRD_VERSION=${PROM_OPERATOR_CRD_VERSION:-v0.44.1}
 if [ "$PROM_OPERATOR_CRD_UPDATE" == "true" ]; then
   log_info "Updating Prometheus Operator custom resource definitions"
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/$PROM_OPERATOR_CRD_VERSION/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -139,7 +139,7 @@ else
   fi
   log_info "Installing via Helm...($(date) - timeout 20m)"
 fi
-KUBE_PROM_STACK_CHART_VERSION=${KUBE_PROM_STACK_CHART_VERSION:-11.1.3}
+KUBE_PROM_STACK_CHART_VERSION=${KUBE_PROM_STACK_CHART_VERSION:-12.8.0}
 helm $helmDebug upgrade --install $promRelease \
   --namespace $MON_NS \
   -f monitoring/values-prom-operator.yaml \

--- a/monitoring/user.env
+++ b/monitoring/user.env
@@ -35,10 +35,10 @@
 # match the value of prometheusOperator.image.tag in the helm YAML
 # if changed from the default.
 # See https://github.com/prometheus-operator/prometheus-operator/releases
-# PROM_OPERATOR_CRD_VERSION=v0.43.2
+# PROM_OPERATOR_CRD_VERSION=v0.44.1
 
 # Version of the kube-prometheus-stack helm chart to use
-# KUBE_PROM_STACK_CHART_VERSION=11.1.3
+# KUBE_PROM_STACK_CHART_VERSION=12.8.0
 
 # Initial password of the Grafana admin user
 # GRAFANA_ADMIN_PASSWORD=yourPasswordHere

--- a/monitoring/values-prom-operator.yaml
+++ b/monitoring/values-prom-operator.yaml
@@ -72,7 +72,7 @@ prometheus:
     nodePort: 31090
   prometheusSpec:
     image:
-      tag: v2.22.2
+      tag: v2.23.0
     logLevel: info
     logFormat: json
     podAntiAffinity: soft
@@ -165,7 +165,7 @@ nodeExporter:
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
   image:
-    tag: "7.3.1"
+    tag: "7.3.6"
   "grafana.ini":
     analytics:
       check_for_updates: false

--- a/samples/generic-base/monitoring/user.env
+++ b/samples/generic-base/monitoring/user.env
@@ -35,10 +35,10 @@
 # match the value of prometheusOperator.image.tag in the helm YAML
 # if changed from the default.
 # See https://github.com/prometheus-operator/prometheus-operator/releases
-# PROM_OPERATOR_CRD_VERSION=v0.43.2
+# PROM_OPERATOR_CRD_VERSION=v0.44.1
 
 # Version of the kube-prometheus-stack helm chart to use
-# KUBE_PROM_STACK_CHART_VERSION=11.1.3
+# KUBE_PROM_STACK_CHART_VERSION=12.8.0
 
 # Initial password of the Grafana admin user
 # GRAFANA_ADMIN_PASSWORD=yourPasswordHere


### PR DESCRIPTION
kube-prometheus-stack Helm Chart: 11.1.3->12.8.0
Prometheus Operator: 0.43.2->0.44.1
Prometheus: v2.22.2-> v2.23.0
Grafana: 7.3.1->7.3.6