### PR TITLE
Revised doc to specify required cert-manager version

### DIFF
--- a/logging/NOTES_ON_USING_TLS.md
+++ b/logging/NOTES_ON_USING_TLS.md
@@ -8,7 +8,7 @@ TLS requires the use of digital security certificates. These certificates allow 
 
 ## Configure TLS Using cert-manager
 
-By default, the deployment process for the SAS Viya Monitoring solution uses cert-manager to obtain and manage the digital security certificates.
+By default, the deployment process for the SAS Viya Monitoring solution uses cert-manager to obtain and manage the digital security certificates. Version v1.0 or later of cert-manager is required.
 
 The `deploy_logging_open.sh` deployment script automatically obtains the certificates from cert-manager and creates the Kubernetes secrets with the required structure and expected names. The script ensures that the certificates are mounted on the Elasticsearch and Kibana pods in the correct locations.
 

--- a/samples/tls/logging/README.md
+++ b/samples/tls/logging/README.md
@@ -56,5 +56,5 @@ The standard deployment script for the logging components use these TLS secrets 
 
 See [NOTES_ON_USING_TLS](../../../logging/NOTES_ON_USING_TLS.md) for information about generating these secrets.
 
-By default, the deployment process uses [cert-manager](https://cert-manager.io/) to generate the certificates. If cert-manager is not available, you can manually generate the certificates. If the required certificates do not exist and cert-manager is not available, the deployment process fails. The cert-manager component is not required if all of the TLS secrets exist prior to deployment.
+By default, the deployment process uses [cert-manager](https://cert-manager.io/) (version v1.0 or later) to generate the certificates. If cert-manager is not available, you can manually generate the certificates. If the required certificates do not exist and cert-manager is not available, the deployment process fails. The cert-manager component is not required if all of the TLS secrets exist prior to deployment.
 

--- a/samples/tls/monitoring/README.md
+++ b/samples/tls/monitoring/README.md
@@ -62,7 +62,7 @@ The standard deployment script for the monitoring components use these TLS secre
 * `alertmanager-tls-secret`
 * `grafana-tls-secret`
 
-If any of the required certificates do not exist, the deployment process attempts to use [cert-manager](https://cert-manager.io/) to generate the missing
+If any of the required certificates do not exist, the deployment process attempts to use [cert-manager](https://cert-manager.io/) (version v1.0 or later) to generate the missing
 certificates. If the required certificates do not exist and cert-manager is
 not available, the deployment process fails. cert-manager is not required
 if TLS is disabled or if all of the TLS secrets exist prior to deployment.


### PR DESCRIPTION
Added notes in doc to indicate that cert-manager version v1.0 or higher is required.