### PR TITLE
Bump monitoring component versions

### DIFF
--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -76,7 +76,7 @@ fi
 
 # Check if Prometheus Operator CRDs are already installed
 PROM_OPERATOR_CRD_UPDATE=${PROM_OPERATOR_CRD_UPDATE:-true}
-PROM_OPERATOR_CRD_VERSION=${PROM_OPERATOR_CRD_VERSION:-v0.47.0}
+PROM_OPERATOR_CRD_VERSION=${PROM_OPERATOR_CRD_VERSION:-v0.51.2}
 if [ "$PROM_OPERATOR_CRD_UPDATE" == "true" ]; then
   log_info "Updating Prometheus Operator custom resource definitions"
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/$PROM_OPERATOR_CRD_VERSION/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -150,7 +150,7 @@ else
   fi
   log_info "Installing via Helm...($(date) - timeout 20m)"
 fi
-KUBE_PROM_STACK_CHART_VERSION=${KUBE_PROM_STACK_CHART_VERSION:-15.0.0}
+KUBE_PROM_STACK_CHART_VERSION=${KUBE_PROM_STACK_CHART_VERSION:-19.2.2}
 helm $helmDebug upgrade --install $promRelease \
   --namespace $MON_NS \
   -f monitoring/values-prom-operator.yaml \

--- a/monitoring/bin/deploy_monitoring_openshift.sh
+++ b/monitoring/bin/deploy_monitoring_openshift.sh
@@ -121,7 +121,7 @@ else
 fi
 
 log_info "Deploying Grafana..."
-OPENSHIFT_GRAFANA_CHART_VERSION=${OPENSHIFT_GRAFANA_CHART_VERSION:-6.9.1}
+OPENSHIFT_GRAFANA_CHART_VERSION=${OPENSHIFT_GRAFANA_CHART_VERSION:-6.17.2}
 helm upgrade --install $helmDebug \
   -n "$MON_NS" \
   -f "$wnpValuesFile" \

--- a/monitoring/bin/deploy_monitoring_tenant.sh
+++ b/monitoring/bin/deploy_monitoring_tenant.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Deploy Grafana using Helm
-GRAFANA_CHART_VERSION_TENANT=${GRAFANA_CHART_VERSION_TENANT:-6.9.1}
+GRAFANA_CHART_VERSION_TENANT=${GRAFANA_CHART_VERSION_TENANT:-6.17.2}
 helm upgrade --install $helmDebug \
   -n "$VIYA_NS" \
   -f "$wnpGrafanaValuesFile" \

--- a/monitoring/bin/deploy_monitoring_viya.sh
+++ b/monitoring/bin/deploy_monitoring_viya.sh
@@ -48,7 +48,7 @@ set -e
 # Prometheus Pushgateway
 PUSHGATEWAY_ENABLED=${PUSHGATEWAY_ENABLED:-true}
 if [ "$PUSHGATEWAY_ENABLED" == "true" ]; then
-  PUSHGATEWAY_CHART_VERSION=${PUSHGATEWAY_CHART_VERSION:-1.10.1}
+  PUSHGATEWAY_CHART_VERSION=${PUSHGATEWAY_CHART_VERSION:-1.11.0}
   if helm3ReleaseExists prometheus-pushgateway $VIYA_NS; then
     svcClusterIP=$(kubectl get svc -n $VIYA_NS prometheus-pushgateway -o 'jsonpath={.spec.clusterIP}')
   fi

--- a/monitoring/kube-hpa-alert-patch.json
+++ b/monitoring/kube-hpa-alert-patch.json
@@ -2,6 +2,6 @@
   {
     "op" : "replace",
     "path" : "/spec/groups/0/rules/14/expr",
-    "value" : "(kube_hpa_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_hpa_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and kube_hpa_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > 1"
+    "value" : "(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > 1"
   }
 ]

--- a/monitoring/user.env
+++ b/monitoring/user.env
@@ -35,10 +35,10 @@
 # match the value of prometheusOperator.image.tag in the helm YAML
 # if changed from the default.
 # See https://github.com/prometheus-operator/prometheus-operator/releases
-# PROM_OPERATOR_CRD_VERSION=v0.47.0
+# PROM_OPERATOR_CRD_VERSION=v0.51.2
 
 # Version of the kube-prometheus-stack helm chart to use
-# KUBE_PROM_STACK_CHART_VERSION=15.0.0
+# KUBE_PROM_STACK_CHART_VERSION=19.2.2
 
 # Initial password of the Grafana admin user
 # GRAFANA_ADMIN_PASSWORD=yourPasswordHere

--- a/monitoring/values-prom-operator.yaml
+++ b/monitoring/values-prom-operator.yaml
@@ -9,7 +9,6 @@
 # Default Values
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
 
-
 commonLabels:
   sas.com/monitoring-base: kube-viya-monitoring
 
@@ -18,16 +17,20 @@ commonLabels:
 # ===================
 # https://github.com/coreos/prometheus-operator
 prometheusOperator:
+  image:
+    tag: v0.51.2
   logFormat: json
   logLevel: info
   createCustomResource: false
+  prometheusConfigReloaderImage:
+    tag: v0.51.2
   resources:
     requests:
       cpu: "100m"
       memory: "50Mi"
     limits:
-      cpu: "250m"
-      memory: "1Gi"
+      cpu: "500m"
+      memory: "2Gi"
   tlsProxy:
     resources:
       requests:
@@ -57,11 +60,11 @@ kubeStateMetrics:
 # https://github.com/helm/charts/tree/master/stable/kube-state-metrics
 kube-state-metrics:
   image:
-    tag: v1.9.8
+    tag: v2.2.1
   resources:
     requests:
       cpu: "25m"
-      memory: "30Mi"
+      memory: "50Mi"
 
 # ==========
 # Prometheus
@@ -74,7 +77,7 @@ prometheus:
     nodePort: null  
   prometheusSpec:
     image:
-      tag: v2.26.1
+      tag: v2.30.3
     logLevel: info
     logFormat: json
     podAntiAffinity: soft
@@ -111,7 +114,7 @@ alertmanager:
     nodePort: null  
   alertmanagerSpec:
     image:
-      tag: v0.21.0
+      tag: v0.23.0
     logFormat: json
     podAntiAffinity: soft
     retention: 240h
@@ -135,17 +138,17 @@ alertmanager:
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter
 prometheus-node-exporter:
   image:
-    tag: v1.0.1
+    tag: v1.2.2
   service:
     # Override the default port of 9100 to avoid potential conflicts
     port: 9110
     targetPort: 9110
   resources:
     requests:
-      cpu: "30m"
+      cpu: "50m"
       memory: "50Mi"
     limits:
-      cpu: "100m"
+      cpu: "250m"
       memory: "100Mi"
   # Be very tolerant
   tolerations:
@@ -167,7 +170,7 @@ nodeExporter:
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
   image:
-    tag: "7.5.4"
+    tag: "8.2.1"
   "grafana.ini":
     analytics:
       check_for_updates: false

--- a/monitoring/values-pushgateway.yaml
+++ b/monitoring/values-pushgateway.yaml
@@ -1,6 +1,6 @@
 image:
   repository: prom/pushgateway
-  tag: v1.4.1
+  tag: v1.4.2
 
 securityContext: null
 


### PR DESCRIPTION

Component | Version in Use | Current Version | Comments
-- | -- | -- | --
kube-prometheus-stack | 15.0.0 | 19.2.2 | Support for Grafana 8.x, Prometheus Operator 0.50+, and removal of obsolete (k8s 1.14) dashboards
Prometheus Operator | 0.47.0 | 0.51.2 | CRDs now support direct TLS support for Prometheus and Alertmanager. This would simplify our TLS support greatly.Support for Kubernetes 1.22 is important here as well.
Prometheus | 2.26.1 | 2.30.3 | Nothing particularly interesting, but bug fixes as well as performance improvements can be important.
Grafana | 7.5.4 | 8.2.1 | In addition to the previously discussed Grafana 8 enhancements\, the 8.2.x release has even more useful features.  Some notable features of 8.x include:Several usability improvements to the UICompletely new Alerting framework with better integration with Prometheus and AlertmanagerNew and enhanced widgets - the state time visualization can be particularly useful to usEnhanced log viewing/filtering as well as enhanced Loki supportImproved Elasticsearch queryingMany bug fixes
Alertmanager | 0.21.0 | 0.23.0 | The big change we would use is built-in TLS support. Improvements for various routing targets could be of interest to users.
Node Exporter | 1.0.1 | 1.2.2 | After a year of nothing, there's been a flurry of activity supporting both new metric categories as well as a slew of bug fixes.
kube-state-metrics | 1.9.8 | 2.2.1 | kube-state-metrics moved to a new major version. We rely on this for several of our custom dashboards. Some updates are required for some dashboards (see #199).

