### PR TITLE
V4m version tracking

### DIFF
--- a/bin/version-include.sh
+++ b/bin/version-include.sh
@@ -51,6 +51,7 @@ function populateValuesYAML() {
 
 function deployV4MInfo() {
   NS=$1
+  releaseName=$2
   if [ -z "$NS" ]; then
     log_error "No namespace specified for deploying Viya Monitoring for Kubernetes version information"
     return 1
@@ -63,17 +64,18 @@ function deployV4MInfo() {
   helm upgrade --install \
     -n "$NS" \
     --values $valuesYAML \
-    v4m ./v4m-chart
+    $releaseName ./v4m-chart
 }
 
 function removeV4MInfo() {
   NS=$1
+  releaseName=$2
   if [ -z "$NS" ]; then
     log_error "No namespace specified for removing Viya Monitoring for Kubernetes version information"
     return 1
   fi
   log_info "Removing Viya Monitoring for Kubernetes version information"
-  helm uninstall -n "$NS" v4m
+  helm uninstall -n "$NS" "$releaseName"
 }
 
 if [ -z "$V4M_VERSION_INCLUDE" ]; then

--- a/logging/bin/deploy_logging_open.sh
+++ b/logging/bin/deploy_logging_open.sh
@@ -86,7 +86,7 @@ logging/bin/deploy_fluentbit_open.sh
 # Version Info                   #
 ##################################
 
-if ! deployV4MInfo "$LOG_NS"; then
+if ! deployV4MInfo "$LOG_NS" "v4m"; then
   log_warn "Unable to update SAS Viya Monitoring version information"
 fi
 

--- a/logging/bin/deploy_logging_open_openshift.sh
+++ b/logging/bin/deploy_logging_open_openshift.sh
@@ -127,7 +127,7 @@ logging/bin/deploy_servicemonitors_open_openshift.sh
 # Version Info                   #
 ##################################
 log_info "STEP 7: Updating version info"
-if ! deployV4MInfo "$LOG_NS"; then
+if ! deployV4MInfo "$LOG_NS" "v4m"; then
   log_warn "Unable to update SAS Viya Monitoring version info"
 fi
 

--- a/logging/bin/remove_logging_open.sh
+++ b/logging/bin/remove_logging_open.sh
@@ -50,7 +50,7 @@ if [ "$LOG_DELETE_CONFIGMAPS_ON_REMOVE" == "true" ]; then
   kubectl delete configmap --ignore-not-found -n $LOG_NS -l managed-by=v4m-es-script
 fi
 
-removeV4MInfo "$LOG_NS"
+removeV4MInfo "$LOG_NS" "v4m"
 
 if [ "$LOG_DELETE_NAMESPACE_ON_REMOVE" == "true" ]; then
   log_info "Deleting the [$LOG_NS] namespace..."

--- a/logging/bin/remove_logging_open_openshift.sh
+++ b/logging/bin/remove_logging_open_openshift.sh
@@ -35,7 +35,6 @@ logging/bin/remove_servicemonitors_open_openshift.sh
 export CHECK_OPENSHIFT_CLUSTER=false
 logging/bin/remove_logging_open.sh
 
-
 log_info "Log monitoring component removal script has completed."
 
 log_debug "Script [$this_script] has completed [$(date)]"

--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -232,8 +232,8 @@ gf_url=$(get_service_url $MON_NS v4m-grafana  "false")
 # am_url=$(get_url $MON_NS v4m-alertmanager  "false")
 set -e
 
-if ! deployV4MInfo "$MON_NS"; then
-  log_warn "Unable to update SAS Viya Monitoring version info"
+if ! deployV4MInfo "$MON_NS" "v4m"; then
+  log_warn "Unable to update SAS Viya Monitoring version information"
 fi
 
 # Print URL to access web apps

--- a/monitoring/bin/deploy_monitoring_openshift.sh
+++ b/monitoring/bin/deploy_monitoring_openshift.sh
@@ -208,7 +208,7 @@ if ! kubectl get route -n $MON_NS v4m-grafana 1>/dev/null 2>&1; then
   fi
 fi
 
-if ! deployV4MInfo "$MON_NS"; then
+if ! deployV4MInfo "$MON_NS" "v4m"; then
   log_warn "Unable to update SAS Viya Monitoring version info"
 fi
 

--- a/monitoring/bin/deploy_monitoring_tenant.sh
+++ b/monitoring/bin/deploy_monitoring_tenant.sh
@@ -187,6 +187,8 @@ DASH_NS=$VIYA_NS
 DASH_BASE=$tenantDir/dashboards
 deploy_tenant_dashboards monitoring/multitenant/dashboards
 
+deployV4MInfo "$VIYA_NS" "v4m-tenant-$VIYA_TENANT"
+
 if [ "$showPass" == "true" ]; then
   # Find the grafana pod
   grafanaPod="$(kubectl get po -n $VIYA_NS -l app.kubernetes.io/name=grafana --template='{{range .items}}{{.metadata.name}}{{end}}')"

--- a/monitoring/bin/deploy_monitoring_tenant_openshift.sh
+++ b/monitoring/bin/deploy_monitoring_tenant_openshift.sh
@@ -252,6 +252,8 @@ if [ ! "$OPENSHIFT_AUTH_ENABLE" == "true" ]; then
   fi
 fi
 
+deployV4MInfo "$VIYA_NS" "v4m-tenant-$VIYA_TENANT"
+
 log_notice "Grafana URL is https://$(kubectl get route -n $VIYA_NS v4m-grafana-$VIYA_TENANT -o jsonpath='{ .spec.host }/{ .spec.path }')"
 
 log_message ""

--- a/monitoring/bin/deploy_monitoring_viya.sh
+++ b/monitoring/bin/deploy_monitoring_viya.sh
@@ -88,3 +88,6 @@ if [ "$(kubectl get crd servicemonitors.monitoring.coreos.com -o name 2>/dev/nul
 else
   log_warn "Prometheus Operator not found. Skipping deployment of ServiceMonitors."
 fi
+
+deployV4MInfo "$VIYA_NS" "v4m-viya"
+

--- a/monitoring/bin/remove_monitoring_cluster.sh
+++ b/monitoring/bin/remove_monitoring_cluster.sh
@@ -65,7 +65,7 @@ if [ "$MON_DELETE_PVCS_ON_REMOVE" == "true" ]; then
   kubectl delete pvc --ignore-not-found -n $MON_NS -l app=prometheus
 fi
 
-removeV4MInfo "$MON_NS"
+removeV4MInfo "$MON_NS" "v4m"
 
 # Wait for resources to terminate
 log_info "Waiting 60 sec for resources to terminate"

--- a/monitoring/bin/remove_monitoring_openshift.sh
+++ b/monitoring/bin/remove_monitoring_openshift.sh
@@ -34,7 +34,7 @@ log_info "Removing clusterrole and clusterrolebinding..."
 kubectl delete --ignore-not-found clusterrole v4m-grafana-clusterrole
 kubectl delete --ignore-not-found clusterrolebinding v4m-grafana-clusterrolebinding
 
-removeV4MInfo "$MON_NS"
+removeV4MInfo "$MON_NS" "v4m"
 
 if [ "$MON_DELETE_NAMESPACE_ON_REMOVE" == "true" ]; then
   log_info "Deleting the [$MON_NS] namespace..."

--- a/monitoring/bin/remove_monitoring_tenant.sh
+++ b/monitoring/bin/remove_monitoring_tenant.sh
@@ -79,4 +79,6 @@ if [ "$OPENSHIFT_CLUSTER" == "true" ]; then
   kubectl delete route -n $VIYA_NS v4m-grafana-$VIYA_TENANT
 fi
 
+removeV4MInfo "$VIYA_NS" "v4m-tenant-$VIYA_TENANT"
+
 log_notice "Uninstalled monitoring for [$VIYA_NS/$VIYA_TENANT]"

--- a/monitoring/bin/remove_monitoring_tenant_openshift.sh
+++ b/monitoring/bin/remove_monitoring_tenant_openshift.sh
@@ -75,4 +75,6 @@ for type in "${types[@]}"; do
   kubectl delete --ignore-not-found $type -n $VIYA_NS -l "v4m.sas.com/tenant=$VIYA_TENANT" >/dev/null
 done
 
+removeV4MInfo "$VIYA_NS" "v4m-tenant-$VIYA_TENANT"
+
 log_notice "Successfully removed OpenShift tenant monitoring for [$VIYA_NS/$VIYA_TENANT]"

--- a/monitoring/bin/remove_monitoring_viya.sh
+++ b/monitoring/bin/remove_monitoring_viya.sh
@@ -40,4 +40,6 @@ if [ "$MON_DELETE_PVCS_ON_REMOVE" == "true" ]; then
   kubectl delete pvc -n $MON_NS -l app=prometheus-pushgateway
 fi
 
+removeV4MInfo "$VIYA_NS" "v4m-viya"
+
 log_info "Removed monitoring components from the [$VIYA_NS] namespace"


### PR DESCRIPTION
- Updated **deployV4MInfo** and **removeV4MInfo** to take two parameters - a namespace and a release name.
- Updated all invocations of **deployV4MInfo** and **removeV4MInfo** to take two parameters.
- For monitoring, the release names are as follows:  v4m (cluster-level), v4m-viya (SAS Viya level), viya-tenant-$VIYA_TENANT (tenant-level).  For logging, v4m is the only name used (same behavior).
- Created the **getHelmReleaseVersion** function to set the Helm version of a component, given a namespace and release name.