### PR TITLE
Added functionality to automatically add Elasticsearch data source in…

### DIFF
--- a/monitoring/bin/common.sh
+++ b/monitoring/bin/common.sh
@@ -4,6 +4,39 @@
 # This file is not marked as executable as it is intended to be sourced
 # Current directory must be the root directory of the repo
 
+function configureElasticsearchDatasource() {
+  # Check to see if logging components have already been deployed.
+  if [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
+    log_verbose "No logging components found.  Skipping Elasticsearch data source set up.";
+  elif [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) > 1 ]]; then
+    log_verbose "Too many logging components found.  Skipping Elasticsearch data source set up.";
+  else
+    # Replace logging namespace name and password in grafana-datasource-es.yaml file
+    logNS=$(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq)
+    monDir=$TMP_DIR/$MON_NS
+    mkdir -p $monDir
+    cp -R monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
+  
+    # Pull Elasticsearch password in temp directory file
+    adminPass="$(kubectl -n $logNS get secret internal-user-admin -o=jsonpath="{.data.password}" | base64 --decode)"
+    
+    # Replace placeholders
+    log_debug "Replacing logging namespace for files in [$monDir]"
+    if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
+      sed -i '' "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
+      sed -i '' "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+    else
+      sed -i "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
+      sed -i "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+    fi
+  
+    log_info "Provisioning Elasticsearch datasource for Grafana"
+    kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
+    kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file $monDir/grafana-datasource-es.yaml
+    kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
+  fi
+}
+
 if [ "$SAS_MONITORING_COMMON_SOURCED" = "" ]; then
   source bin/common.sh
 
@@ -21,5 +54,6 @@ if [ "$SAS_MONITORING_COMMON_SOURCED" = "" ]; then
 
   source bin/version-include.sh
   export SAS_MONITORING_COMMON_SOURCED=true
+  export -f configureElasticsearchDatasource
 fi
 echo ""

--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -65,10 +65,37 @@ fi
 # Elasticsearch Datasource for Grafana
 ELASTICSEARCH_DATASOURCE="${ELASTICSEARCH_DATASOURCE:-false}"
 if [ "$ELASTICSEARCH_DATASOURCE" == "true" ]; then
-  log_verbose "Provisioning Elasticsearch datasource for Grafana"
-  kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
-  kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file monitoring/grafana-datasource-es.yaml
-  kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
+
+  # Check to see if logging components have already been deployed.
+  if [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
+    log_verbose "No logging components found.  Skipping Elasticsearch data source set up.";
+  elif [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) > 1 ]]; then
+    log_verbose "Too many logging components found.  Skipping Elasticsearch data source set up.";
+  else
+    # Replace logging namespace name and password in grafana-datasource-es.yaml file
+    logNS=$(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq)
+    monDir=$TMP_DIR/$MON_NS
+    mkdir -p $monDir
+    cp -R monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
+  
+    # Pull Elasticsearch password in temp directory file
+    adminPass="$(kubectl -n $logNS get secret internal-user-admin -o=jsonpath="{.data.password}" | base64 --decode)"
+    
+    # Replace placeholders
+    log_debug "Replacing logging namespace for files in [$monDir]"
+    if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
+      sed -i '' "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
+      sed -i '' "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+    else
+      sed -i "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
+      sed -i "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+    fi
+  
+    log_info "Provisioning Elasticsearch datasource for Grafana"
+    kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
+    kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file $monDir/grafana-datasource-es.yaml
+    kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
+  fi
 else
   log_debug "ELASTICSEARCH_DATASOURCE not set"
   log_debug "Skipping creation of Elasticsearch datasource for Grafana"

--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -65,37 +65,7 @@ fi
 # Elasticsearch Datasource for Grafana
 ELASTICSEARCH_DATASOURCE="${ELASTICSEARCH_DATASOURCE:-false}"
 if [ "$ELASTICSEARCH_DATASOURCE" == "true" ]; then
-
-  # Check to see if logging components have already been deployed.
-  if [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
-    log_verbose "No logging components found.  Skipping Elasticsearch data source set up.";
-  elif [[ $(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) > 1 ]]; then
-    log_verbose "Too many logging components found.  Skipping Elasticsearch data source set up.";
-  else
-    # Replace logging namespace name and password in grafana-datasource-es.yaml file
-    logNS=$(kubectl get pods -A -l app.kubernetes.io/instance=v4m-fb -o custom-columns=:metadata.namespace --no-headers | uniq)
-    monDir=$TMP_DIR/$MON_NS
-    mkdir -p $monDir
-    cp -R monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
-  
-    # Pull Elasticsearch password in temp directory file
-    adminPass="$(kubectl -n $logNS get secret internal-user-admin -o=jsonpath="{.data.password}" | base64 --decode)"
-    
-    # Replace placeholders
-    log_debug "Replacing logging namespace for files in [$monDir]"
-    if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
-      sed -i '' "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
-      sed -i '' "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
-    else
-      sed -i "s/__logNS__/$logNS/g" $monDir/grafana-datasource-es.yaml
-      sed -i "s/__adminPass__/$adminPass/g" $monDir/grafana-datasource-es.yaml
-    fi
-  
-    log_info "Provisioning Elasticsearch datasource for Grafana"
-    kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
-    kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file $monDir/grafana-datasource-es.yaml
-    kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
-  fi
+  configureElasticsearchDatasource
 else
   log_debug "ELASTICSEARCH_DATASOURCE not set"
   log_debug "Skipping creation of Elasticsearch datasource for Grafana"

--- a/monitoring/bin/deploy_monitoring_openshift.sh
+++ b/monitoring/bin/deploy_monitoring_openshift.sh
@@ -51,6 +51,15 @@ else
   log_warn "Ensure that user workload monitoring is enabled"
 fi
 
+# Elasticsearch Datasource for Grafana
+ELASTICSEARCH_DATASOURCE="${ELASTICSEARCH_DATASOURCE:-false}"
+if [ "$ELASTICSEARCH_DATASOURCE" == "true" ]; then
+  configureElasticsearchDatasource
+else
+  log_debug "ELASTICSEARCH_DATASOURCE not set"
+  log_debug "Skipping creation of Elasticsearch datasource for Grafana"
+fi
+
 log_info "Enabling Grafana to access OpenShift Prometheus instances..."
 if [ -z "$(kubectl get serviceAccount -n $MON_NS grafana-serviceaccount -o name 2>/dev/null)" ]; then
   log_info "Creating Grafana serviceAccount..."

--- a/monitoring/grafana-datasource-es.yaml
+++ b/monitoring/grafana-datasource-es.yaml
@@ -4,8 +4,8 @@ datasources:
 - name: Elastic
   type: elasticsearch
   access: proxy
-  database: kubernetes_cluster-*
-  url: https://v4m-es-client-service.logging:9200
+  database: viya_logs-*
+  url: https://v4m-es-client-service.__logNS__:9200
   basicAuth: true
   basicAuthUser: admin
   jsonData:
@@ -16,5 +16,5 @@ datasources:
     logLevelField: level
   secureJsonData:
     # Change this value
-    basicAuthPassword: YOUR_PASSWORD_HERE
+    basicAuthPassword: __adminPass__
   editable: true


### PR DESCRIPTION
… logging namespace.

The ELASTICSEARCH_DATASOURCE environment variable already existed (only in the deploy_monitoring_cluster script).  

Added logic to count unique namespaces where our Fluent Bit pod exists.  If there is only one, it will set up the Elasticsearch data source using the admin user ID and password.
