### PR TITLE
Added CPU/memory limit to logging components per Helm chart defaults.

### DIFF
--- a/logging/es/odfe/es_helm_values_open.yaml
+++ b/logging/es/odfe/es_helm_values_open.yaml
@@ -1,5 +1,5 @@
-# Helm Chart: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/Chart.yaml
-# Default values: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/v
+# Helm Chart: https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/helm/opendistro-es/Chart.yaml
+# Default values: https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/main/helm/opendistro-es/values.yaml
 
 elasticsearch:
   imageTag: 1.13.2

--- a/logging/es/odfe/es_helm_values_open.yaml
+++ b/logging/es/odfe/es_helm_values_open.yaml
@@ -1,3 +1,6 @@
+# Helm Chart: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/Chart.yaml
+# Default values: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/v
+
 elasticsearch:
   imageTag: 1.13.2
 
@@ -123,6 +126,13 @@ elasticsearch:
       enabled: true
       #storageClass: alt-storage
       size: 8Gi
+    resources:
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
 
   data:
     enabled: true
@@ -163,6 +173,13 @@ elasticsearch:
       enabled: true
       #storageClass: alt-storage
       size: 30Gi
+    resources:
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
 
   client:
     enabled: true
@@ -198,6 +215,15 @@ elasticsearch:
                 - "true"
             topologyKey: kubernetes.io/hostname
           weight: 25
+    resources:
+    #  limits:
+    #    cpu: 1
+    #    memory: 1024Mi
+      requests:
+        cpu: 200m
+        memory: 1024Mi
+
+
 
 kibana:
   imageTag: 1.13.2
@@ -213,6 +239,13 @@ kibana:
       secretKeyRef:
         name: internal-user-kibanaserver
         key: password
+  resources:
+  #  limits:
+  #    cpu: 2500m
+  #    memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
 
   service:
     type: NodePort

--- a/logging/esexporter/values-es-exporter_open.yaml
+++ b/logging/esexporter/values-es-exporter_open.yaml
@@ -1,3 +1,6 @@
+# Helm Chart: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/Chart.yaml
+# Default values: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-elasticsearch-exporter/values.yaml
+
 ## number of exporter instances
 ##
 replicaCount: 1
@@ -24,10 +27,10 @@ securityContext:
   enabled: true  # Should be set to false when running on OpenShift
   runAsUser: 1000
 
-resources: {}
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
   # limits:
   #   cpu: 100m
   #   memory: 128Mi

--- a/logging/eventrouter/eventrouter.yaml
+++ b/logging/eventrouter/eventrouter.yaml
@@ -1,3 +1,5 @@
+# Default values: https://github.com/heptiolabs/eventrouter/blob/master/yaml/eventrouter.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/logging/fb/fluent-bit_helm_values_azmonitor.yaml
+++ b/logging/fb/fluent-bit_helm_values_azmonitor.yaml
@@ -2,7 +2,7 @@
 # Default values: https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml
 
 image:
-  tag: 1.7.9
+  tag: 1.8.7
 podAnnotations: 
   fluentbit.io/parser: fluentbit
 podLabels:

--- a/logging/fb/fluent-bit_helm_values_azmonitor.yaml
+++ b/logging/fb/fluent-bit_helm_values_azmonitor.yaml
@@ -1,3 +1,6 @@
+# Chart:  https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/Chart.yaml
+# Default values: https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml
+
 image:
   tag: 1.7.9
 podAnnotations: 
@@ -45,3 +48,11 @@ envFrom:
 # Be very tolerant
 tolerations:
 - operator: "Exists"
+
+resources:
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/logging/fb/fluent-bit_helm_values_open.yaml
+++ b/logging/fb/fluent-bit_helm_values_open.yaml
@@ -1,3 +1,8 @@
+# Override values for the Fluent Bit helm chart
+#
+# Chart:  https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/Chart.yaml
+# Default values: https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml
+
 image:
   tag: 1.8.7
 podAnnotations: 
@@ -37,3 +42,11 @@ envFrom:
 # Be very tolerant
 tolerations:
 - operator: "Exists"
+
+resources:
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
Verified that every pod (except for Event Router) had a CPU/memory request with kubectl get pod --output=yaml -n logging and grepped for requests to confirm that they were all added.
The Event Router default YAML did not specify any limits so I did not add any at this time.
