### PR TITLE
Removing unused variable that was causing errors in deployment

### DIFF
--- a/logging/bin/deploy_kibana_content.sh
+++ b/logging/bin/deploy_kibana_content.sh
@@ -76,16 +76,6 @@ kubectl -n logging wait pods --selector app=v4m-es,role=kibana --for condition=R
 set +e
 get_kb_api_url
 
-set -e
-
-if [ "$kibanaready" != "TRUE" ]; then
-   log_error "The Kibana REST endpoint has NOT become accessible in the expected time; exiting."
-   log_error "Review the Kibana pod's events and log to identify the issue and resolve it before trying again."
-   exit 1
-fi
-
-set +e  # disable exit on error
-
 # get Security API URL
 get_sec_api_url
 


### PR DESCRIPTION
I did a few attempts to fix previous merge conflict issues but, in the last one that I did that got merged, I forgot to remove some logic that was associated with the old pause loops.

Removing the 'kibanaready' check that was causing the latest failures.