### PR TITLE
Add scripts to configure Elasticsearch data source

### DIFF
--- a/monitoring/bin/create_elasticsearch_datasource_cluster.sh
+++ b/monitoring/bin/create_elasticsearch_datasource_cluster.sh
@@ -16,30 +16,32 @@ export LOG_NS="${LOG_NS:-logging}"
 # Check to see if monitoring namespace provided exists and components have already been deployed
 log_info "Checking for Grafana pods in the $MON_NS namespace ..."
 if [[ $(kubectl get pods -n $MON_NS -l app.kubernetes.io/instance=v4m-prometheus-operator -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
-  log_error "No monitoring components found in the $MON_NS namespace.  Monitoring needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
+  log_error "No monitoring components found in the $MON_NS namespace."
+  log_error "Monitoring needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
   exit 1
 else
-  log_verbose "Monitoring found in $MON_NS namespace.  Continuing."
+  log_debug "Monitoring found in $MON_NS namespace.  Continuing."
 fi
 
 # Check to see if logging namespace provided exists and components have already been deployed
 log_info "Checking for Elasticsearch pods in the $LOG_NS namespace ..."
 if [[ $(kubectl get pods -A -l app=v4m-es -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
-  log_error "No logging components found in the $LOG_NS namespace.  Logging needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
+  log_error "No logging components found in the $LOG_NS namespace."
+  log_error "Logging needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
 else
-  log_verbose "Logging found in $LOG_NS namespace.  Continuing."
+  log_debug "Logging found in $LOG_NS namespace.  Continuing."
 fi
 
 # Create temporary directory for string replacement in the grafana-datasource-es.yaml file
   monDir=$TMP_DIR/$MON_NS
   mkdir -p $monDir
-  cp -R monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
+  cp monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
 
-# Pull Elasticsearch password in temp directory file
+# Retrieving Elasticsearch password for data source setup
 adminPass="$(kubectl -n $LOG_NS get secret internal-user-admin -o=jsonpath="{.data.password}" | base64 --decode)"
 
 # Replace placeholders
-log_debug "Replacing logging namespace for files in [$monDir]"
+log_debug "Replacing variables in $monDir/grafana-datasource-es.yaml file"
 if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
   sed -i '' "s/__sourceName__/Elastic/g" $monDir/grafana-datasource-es.yaml
   sed -i '' "s/__namespace__/$LOG_NS/g" $monDir/grafana-datasource-es.yaml
@@ -47,19 +49,22 @@ if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
   sed -i '' "s/__passwd__/$adminPass/g" $monDir/grafana-datasource-es.yaml
 else
   sed -i "s/__sourceName__/Elastic/g" $monDir/grafana-datasource-es.yaml
-  sed -i "s/__namespace__/$logNS/g" $monDir/grafana-datasource-es.yaml
+  sed -i "s/__namespace__/$LOG_NS/g" $monDir/grafana-datasource-es.yaml
   sed -i "s/__userID__/admin/g" $monDir/grafana-datasource-es.yaml
   sed -i "s/__passwd__/$adminPass/g" $monDir/grafana-datasource-es.yaml
 fi
-  
+
+if [ ! -z "$(kubectl get secret -n $MON_NS grafana-datasource-es -o custom-columns=:metadata.name --no-headers --ignore-not-found)"]; then
+  log_info "Removing existing Elasticsearch data source ..."
+  kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
+fi
+
 log_info "Provisioning Elasticsearch datasource for Grafana"
-kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
 kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file $monDir/grafana-datasource-es.yaml
 kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
 
 # Delete pods so that they can be restarted with the change.
 iog_info "Elasticsearch data source provisioned.  Restarting pods to apply the change"
-kubectl delete pods -n $tenantNS -l "app.kubernetes.io/instance=v4m-grafana-acme"
-kubectl -n $tenantNS wait pods --selector app.kubernetes.io/instance=v4m-grafana-acme --for condition=Ready --timeout=2m
+kubectl delete pods -n $MON_NS -l "app.kubernetes.io/instance=v4m-grafana"
+kubectl -n $MON_NS wait pods --selector app.kubernetes.io/instance=v4m-grafana --for condition=Ready --timeout=2m
 log_info "Elasticsearch data source has been configured."
-

--- a/monitoring/bin/create_elasticsearch_datasource_cluster.sh
+++ b/monitoring/bin/create_elasticsearch_datasource_cluster.sh
@@ -1,0 +1,65 @@
+#! /bin/bash
+
+# Copyright © 2022, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Prerequisites:
+# If cluster, cluster level needs to be deployed.  Uses $LOG_NS and $MON_NS.  If tenant, provide namespace, tenant name, user, password.
+# If tenant, tenant needs to be onboarded.  Need to provide namespace (default to usual monitoring/logging), tenant, user, password.
+
+
+cd "$(dirname $BASH_SOURCE)/../.."
+CHECK_HELM=false
+source monitoring/bin/common.sh
+export LOG_NS="${LOG_NS:-logging}"
+
+# Check to see if monitoring namespace provided exists and components have already been deployed
+log_info "Checking for Grafana pods in the $MON_NS namespace ..."
+if [[ $(kubectl get pods -n $MON_NS -l app.kubernetes.io/instance=v4m-prometheus-operator -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
+  log_error "No monitoring components found in the $MON_NS namespace.  Monitoring needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
+  exit 1
+else
+  log_verbose "Monitoring found in $MON_NS namespace.  Continuing."
+fi
+
+# Check to see if logging namespace provided exists and components have already been deployed
+log_info "Checking for Elasticsearch pods in the $LOG_NS namespace ..."
+if [[ $(kubectl get pods -A -l app=v4m-es -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
+  log_error "No logging components found in the $LOG_NS namespace.  Logging needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
+else
+  log_verbose "Logging found in $LOG_NS namespace.  Continuing."
+fi
+
+# Create temporary directory for string replacement in the grafana-datasource-es.yaml file
+  monDir=$TMP_DIR/$MON_NS
+  mkdir -p $monDir
+  cp -R monitoring/grafana-datasource-es.yaml $monDir/grafana-datasource-es.yaml
+
+# Pull Elasticsearch password in temp directory file
+adminPass="$(kubectl -n $LOG_NS get secret internal-user-admin -o=jsonpath="{.data.password}" | base64 --decode)"
+
+# Replace placeholders
+log_debug "Replacing logging namespace for files in [$monDir]"
+if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
+  sed -i '' "s/__sourceName__/Elastic/g" $monDir/grafana-datasource-es.yaml
+  sed -i '' "s/__namespace__/$LOG_NS/g" $monDir/grafana-datasource-es.yaml
+  sed -i '' "s/__userID__/admin/g" $monDir/grafana-datasource-es.yaml
+  sed -i '' "s/__passwd__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+else
+  sed -i "s/__sourceName__/Elastic/g" $monDir/grafana-datasource-es.yaml
+  sed -i "s/__namespace__/$logNS/g" $monDir/grafana-datasource-es.yaml
+  sed -i "s/__userID__/admin/g" $monDir/grafana-datasource-es.yaml
+  sed -i "s/__passwd__/$adminPass/g" $monDir/grafana-datasource-es.yaml
+fi
+  
+log_info "Provisioning Elasticsearch datasource for Grafana"
+kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
+kubectl create secret generic -n $MON_NS grafana-datasource-es --from-file $monDir/grafana-datasource-es.yaml
+kubectl label secret -n $MON_NS grafana-datasource-es grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
+
+# Delete pods so that they can be restarted with the change.
+iog_info "Elasticsearch data source provisioned.  Restarting pods to apply the change"
+kubectl delete pods -n $tenantNS -l "app.kubernetes.io/instance=v4m-grafana-acme"
+kubectl -n $tenantNS wait pods --selector app.kubernetes.io/instance=v4m-grafana-acme --for condition=Ready --timeout=2m
+log_info "Elasticsearch data source has been configured."
+

--- a/monitoring/bin/create_elasticsearch_datasource_cluster.sh
+++ b/monitoring/bin/create_elasticsearch_datasource_cluster.sh
@@ -54,7 +54,7 @@ else
   sed -i "s/__passwd__/$adminPass/g" $monDir/grafana-datasource-es.yaml
 fi
 
-if [ ! -z "$(kubectl get secret -n $MON_NS grafana-datasource-es -o custom-columns=:metadata.name --no-headers --ignore-not-found)"]; then
+if [ -n "$(kubectl get secret -n $MON_NS grafana-datasource-es -o custom-columns=:metadata.name --no-headers --ignore-not-found)"]; then
   log_info "Removing existing Elasticsearch data source ..."
   kubectl delete secret -n $MON_NS --ignore-not-found grafana-datasource-es
 fi

--- a/monitoring/bin/create_elasticsearch_datasource_tenant.sh
+++ b/monitoring/bin/create_elasticsearch_datasource_tenant.sh
@@ -134,7 +134,8 @@ get_sec_api_url
 get_credentials_from_secret admin
 
 if ! kibana_tenant_exists "${tenantNS}_${tenant}"; then
-  log_error "Unable to configure Elasticsearch data source.  The $tenant tenant has not been onboarded.";
+  log_error "Unable to configure Elasticsearch data source."
+  log_error "The $tenant tenant in the $tenantNS namespace has not been onboarded.";
   exit 1
 else
   log_debug "The $tenant tenant has been been onboarded in the Elasticsearch.  Continuing."

--- a/monitoring/bin/create_elasticsearch_datasource_tenant.sh
+++ b/monitoring/bin/create_elasticsearch_datasource_tenant.sh
@@ -1,0 +1,135 @@
+#! /bin/bash
+
+# Copyright © 2022, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Prerequisites:
+# If cluster, cluster level needs to be deployed.  Uses $LOG_NS and $MON_NS.  If tenant, provide namespace, tenant name, user, password.
+# If tenant, tenant needs to be onboarded.  Need to provide namespace (default to usual monitoring/logging), tenant, user, password.
+
+
+cd "$(dirname $BASH_SOURCE)/../.."
+CHECK_HELM=false
+source monitoring/bin/common.sh
+export LOG_NS="${LOG_NS:-logging}"
+
+function show_usage {
+  log_message  "Usage: $this_script --namespace NAMESPACE --tenant TENANT --user USER --password PASSWORD"
+  log_message  ""
+  log_message  "'Creates the Elasticsearch datasource for a Viya tenant given using user-provided "
+  log_message  "namespace, tenant, and user credentials."
+  log_message  ""
+  log_message  "    Arguments:"
+  log_message  "     -ns, --namespace NAMESPACE   - The namespace where the Viya tenant is resides."
+  log_message  "     -t,  --tenant TENANT         - The tenant whose Elasticsearch data source you want to set up."
+  log_message  "     -u,  --user USER             - The user with access to this Kibana tenant space."
+  log_message  "     -p,  --password PASSWORD     - Password for the initial user."
+  log_message  ""
+}
+
+# Assigning passed in parameters as variables for the script:
+POS_PARMS=""
+
+# Setting passed in variables:
+while (( "$#" )); do
+  case "$1" in
+    -ns|--namespace)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        tenantNS=$2
+        shift 2
+      else
+        log_error "A value for parameter [NAMESPACE] has not been provided." >&2
+        show_usage
+        exit 2
+      fi
+      ;;
+    -t|--tenant)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        tenant=$2
+        shift 2
+      else
+        log_error "A value for parameter [TENANT] has not been provided." >&2
+        show_usage
+        exit 2
+      fi
+      ;;
+    -u|--user)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        userID=$2
+        shift 2
+      else
+        # no initial user name provided, assign default name
+        log_error "A value for parameter [USER] has not been provided." >&2
+        show_usage
+        exit 2
+      fi
+      ;;
+    -p|--password)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        passwd=$2
+        shift 2
+      else
+        log_error "A value for parameter [PASSWORD] has not been provided." >&2
+        show_usage
+        exit 2
+      fi
+      ;;
+    -h|--help)
+      show_usage
+      exit
+      ;;
+    -*|--*=) # unsupported flags
+      log_error "Unsupported flag $1" >&2
+      show_usage
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      POS_PARMS="$POS_PARMS $1"
+      shift
+      ;;
+  esac
+done
+
+# Convert namespace and tenant to all lower-case
+tenantNS=$(echo "$tenantNS"| tr '[:upper:]' '[:lower:]')
+tenant=$(echo "$tenant"| tr '[:upper:]' '[:lower:]')
+
+# Check to see if monitoring deployment could be found for tenant in provided namespace
+log_info "Checking the $tenantNS namespace for monitoring deployment for the $tenant tenant ..."
+if [[ $(kubectl get pods -n $tenantNS -l app.kubernetes.io/instance=v4m-grafana-$tenant -o custom-columns=:metadata.namespace --no-headers | uniq | wc -l) == 0 ]]; then
+    log_error "No monitoring components found in the $tenantNS namespace.  Monitoring needs to be deployed in this namespace in order to configure Elasticsearch with this script.";
+    exit 1
+else
+    log_verbose "Monitoring deployment was found for the $tenant tenant in the $tenantNS namespace.  Continuing."
+fi
+
+# Verify that the password is correct?
+
+
+# Create temporary directory for string replacement in the grafana-datasource-es.yaml file
+tenantDir=$TMP_DIR/$VIYA_TENANT
+mkdir -p $tenantDir
+cp -R monitoring/grafana-datasource-es.yaml $tenantDir/grafana-datasource-es.yaml
+
+# Replace placeholders
+log_debug "Replacing logging namespace for files in [$tenantDir]"
+if echo "$OSTYPE" | grep 'darwin' > /dev/null 2>&1; then
+  sed -i '' "s/__namespace__/$LOG_NS/g" $tenantDir/grafana-datasource-es.yaml
+  sed -i '' "s/__userID__/$userID/g" $tenantDir/grafana-datasource-es.yaml
+  sed -i '' "s/__passwd__/$passwd/g" $tenantDir/grafana-datasource-es.yaml
+else
+  sed -i "s/__namespace__/$LOG_NS/g" $tenantDir/grafana-datasource-es.yaml
+  sed -i "s/__userID__/$userID/g" $tenantDir/grafana-datasource-es.yaml
+  sed -i "s/__passwd__/$passwd/g" $tenantDir/grafana-datasource-es.yaml
+fi
+
+log_info "Provisioning Elasticsearch data source for Grafana"
+kubectl delete secret -n $tenantNS --ignore-not-found v4m-grafana-datasource-es-$tenant
+kubectl create secret generic -n $tenantNS v4m-grafana-datasource-es-$tenant --from-file $tenantDir/grafana-datasource-es.yaml
+kubectl label secret -n $tenantNS v4m-grafana-datasource-es-$tenant grafana_datasource-$tenant=true sas.com/monitoring-base=kube-viya-monitoring
+
+# Delete pods so that they can be restarted with the change.
+iog_info "Elasticsearch data source provisioned.  Restarting pods to apply the change"
+kubectl delete pods -n $tenantNS -l "app.kubernetes.io/instance=v4m-grafana-acme"
+kubectl -n $tenantNS wait pods --selector app.kubernetes.io/instance=v4m-grafana-acme --for condition=Ready --timeout=2m
+log_info "Elasticsearch data source has been configured for the $tenant tenant in the $tenantNS namespace."

--- a/monitoring/grafana-datasource-es.yaml
+++ b/monitoring/grafana-datasource-es.yaml
@@ -5,9 +5,9 @@ datasources:
   type: elasticsearch
   access: proxy
   database: viya_logs-*
-  url: https://v4m-es-client-service.__logNS__:9200
+  url: https://v4m-es-client-service.__namespace__:9200
   basicAuth: true
-  basicAuthUser: admin
+  basicAuthUser: __userID__
   jsonData:
     tlsSkipVerify: true
     timeField: "@timestamp"
@@ -16,5 +16,5 @@ datasources:
     logLevelField: level
   secureJsonData:
     # Change this value
-    basicAuthPassword: __adminPass__
+    basicAuthPassword: __passwd__
   editable: true

--- a/monitoring/multitenant/grafana-datasource-tenant.yaml
+++ b/monitoring/multitenant/grafana-datasource-tenant.yaml
@@ -5,7 +5,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://prometheus-__TENANT__:9090
+    url: http://v4m-prometheus-__TENANT__:9090
     password:
     user:
     database:


### PR DESCRIPTION
- Created two scripts to configure the Elasticsearch data source in Grafana (one for cluster and one for tenant).
- Currently, the tenant admin that's created with the logging onboarding scripts do not have enough permission so, for the time being, we either need to either:
- - Update the permission of the tenant admin user to include **indices:admin/mappings/get** for **viya_logs-* ** in order for it to work as intended (will be creating new users for these scripts in a later release.
- - Use admin user ID.

I also used this opportunity to update a multi-tenant Prometheus YAML file to include the correct URL (v4m-prometheus-__TENANT__:9090).