### PR TITLE
Logging dashboards now deploy when logging data source is added.

### DIFF
--- a/monitoring/bin/create_elasticsearch_datasource.sh
+++ b/monitoring/bin/create_elasticsearch_datasource.sh
@@ -192,6 +192,10 @@ else
     kubectl label secret -n $tenantNS v4m-grafana-datasource-es-$tenant grafana_datasource-$tenant=true sas.com/monitoring-base=kube-viya-monitoring
 fi
 
+# Create the logging dashboard
+WELCOME_DASH="false" KUBE_DASH="false" VIYA_DASH="false" VIYA_LOGS_DASH="false" PGMONITOR_DASH="false" RABBITMQ_DASH="false" NGINX_DASH="false" LOGGING_DASH="true" USER_DASH="false" monitoring/bin/deploy_dashboards.sh
+
+
 # Delete pods so that they can be restarted with the change.
 log_info "Elasticsearch data source provisioned in Grafana.  Restarting pods to apply the change"
 if [ "$cluster" == "true" ]; then


### PR DESCRIPTION
Added logic to the create_elasticsearch_datasource.sh script to deploy the logging-related dashboards.

Since I wasn't able to get the "deploy single dashboard" logic to work from within another script, we're going to call the script and set the flag for the other dashboards to false (so that only the logging dashboards are deployed).