### PR TITLE
Updated Viya log dashboards to use new Elasticsearch data source name

### DIFF
--- a/monitoring/bin/create_elasticsearch_datasource.sh
+++ b/monitoring/bin/create_elasticsearch_datasource.sh
@@ -193,7 +193,7 @@ else
 fi
 
 # Create the logging dashboard
-WELCOME_DASH="false" KUBE_DASH="false" VIYA_DASH="false" VIYA_LOGS_DASH="false" PGMONITOR_DASH="false" RABBITMQ_DASH="false" NGINX_DASH="false" LOGGING_DASH="true" USER_DASH="false" monitoring/bin/deploy_dashboards.sh
+WELCOME_DASH="false" KUBE_DASH="false" VIYA_DASH="false" VIYA_LOGS_DASH="true" PGMONITOR_DASH="false" RABBITMQ_DASH="false" NGINX_DASH="false" LOGGING_DASH="false" USER_DASH="false" monitoring/bin/deploy_dashboards.sh
 
 
 # Delete pods so that they can be restarted with the change.

--- a/monitoring/dashboards/viya-logs/cas-dashboard.json
+++ b/monitoring/dashboards/viya-logs/cas-dashboard.json
@@ -775,7 +775,7 @@
       "id": 23,
       "panels": [
         {
-          "datasource": "Elastic",
+          "datasource": "ViyaLogs",
           "gridPos": {
             "h": 20,
             "w": 24,

--- a/monitoring/dashboards/viya-logs/go-service-dashboard.json
+++ b/monitoring/dashboards/viya-logs/go-service-dashboard.json
@@ -1132,7 +1132,7 @@
       "id": 146,
       "panels": [
         {
-          "datasource": "Elastic",
+          "datasource": "ViyaLogs",
           "gridPos": {
             "h": 24,
             "w": 18,

--- a/monitoring/dashboards/viya-logs/java-service-dashboard.json
+++ b/monitoring/dashboards/viya-logs/java-service-dashboard.json
@@ -3591,7 +3591,7 @@
       "id": 157,
       "panels": [
         {
-          "datasource": "Elastic",
+          "datasource": "ViyaLogs",
           "gridPos": {
             "h": 18,
             "w": 24,


### PR DESCRIPTION
- The create_elasticsearch_datasource script now deploys the Viya-log dashboards (CAS/Go/Java Services) instead of the logging ones (Elasticsearch/Fluent Bit)
- Updated the CAS, Go, and Java Services dashboards to use the new Elasticsearch data source name.
