### PR TITLE
Fixed typo in alertmanagerSpec variable in some files

### DIFF
--- a/monitoring/user-values-prom-operator.yaml
+++ b/monitoring/user-values-prom-operator.yaml
@@ -53,7 +53,7 @@
 
 # alertmanager:
 #   enabled:true
-#   alertManagerSpec:
+#   alertmanagerSpec:
 #     externalUrl: http://host.mycluster.example.com:31091
 #     storage:
 #       volumeClaimTemplate:

--- a/samples/generic-base/monitoring/user-values-prom-operator.yaml
+++ b/samples/generic-base/monitoring/user-values-prom-operator.yaml
@@ -53,7 +53,7 @@
 
 # alertmanager:
 #   enabled:true
-#   alertManagerSpec:
+#   alertmanagerSpec:
 #     externalUrl: http://host.mycluster.example.com:31091
 #     storage:
 #       volumeClaimTemplate:


### PR DESCRIPTION
Found a sample user.env file that also contained the typo so it was fixed there, too.