### PR TITLE
Fix bug that causes v4m-container to fail to build if KUBECONFIG file not provided.

### DIFF
--- a/v4m-container/Dockerfile
+++ b/v4m-container/Dockerfile
@@ -26,8 +26,8 @@ RUN mkdir -p $V4M_PATH/bin $V4M_PATH/.kube $V4M_PATH/user_dir
 WORKDIR $V4M_PATH
 
 # Copy contents from kubeconfig and user_dir to the container
-COPY kubeconfig/* /opt/v4m/.kube/
-COPY user_dir/* /opt/v4m/user_dir/
+COPY kubeconfig/ /opt/v4m/.kube/
+COPY user_dir/ /opt/v4m/user_dir/
 
 RUN chmod 600 ${KUBECONFIG}
 ENV USER_DIR=/opt/v4m/user_dir

--- a/v4m-container/Dockerfile
+++ b/v4m-container/Dockerfile
@@ -25,6 +25,9 @@ ENV KEEP_TMP_DIR=true
 RUN mkdir -p $V4M_PATH/bin $V4M_PATH/.kube $V4M_PATH/user_dir
 WORKDIR $V4M_PATH
 
+# Create $V4M_PATH/.kube/config if it doesn't exist
+RUN touch ${KUBECONFIG}
+
 # Copy contents from kubeconfig and user_dir to the container
 COPY kubeconfig/ /opt/v4m/.kube/
 COPY user_dir/ /opt/v4m/user_dir/


### PR DESCRIPTION
A bug was discovered where the container would fail to build if **$V4M_PATH/.kube/config** did not exist.
Creating an empty KUBECONFIG file if one isn't provided.