### PR TITLE
Changes to sas-opendistro ServiceMonitor so it can be used with prometheus exporter plugin for OpenSearch

### DIFF
--- a/monitoring/monitors/viya/serviceMonitor-sas-opendistro.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-opendistro.yaml
@@ -4,39 +4,13 @@ metadata:
   name: sas-opendistro
 spec:
   endpoints:
-  - basicAuth:
-      password:
-        key: password
-        name: sas-opendistro-sasadmin-secret
-      username:
-        key: username
-        name: sas-opendistro-sasadmin-secret
-    metricRelabelings:
+  - metricRelabelings:
     - action: replace
       sourceLabels:
       - node
       targetLabel: es_node
-    relabelings:
-    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-      action: replace
-      targetLabel: __metrics_path__
-      regex: (.+)
-    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_io_port]
-      action: replace
-      targetLabel: __address__
-      regex: ([^:]+)(?::\d+)?;(\d+)
-      replacement: $1:$2
-    - sourceLabels: [__meta_kubernetes_pod_annotation_sas_com_tls_enabled_ports]
-      action: replace
-      regex: all|.*http.*
-      targetLabel: __scheme__
-      replacement: https
-    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-      action: replace
-      targetLabel: __scheme__
-      regex: (https?)
-    tlsConfig:
-      insecureSkipVerify: true
+    path: /metrics
+    port: http
   selector:
     matchLabels:
-      app.kubernetes.io/name: sas-opendistro
+      app.kubernetes.io/name: sas-opendistro-exporter

--- a/monitoring/monitors/viya/serviceMonitor-sas-opendistro.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-opendistro.yaml
@@ -4,13 +4,39 @@ metadata:
   name: sas-opendistro
 spec:
   endpoints:
-  - metricRelabelings:
+  - basicAuth:
+      password:
+        key: password
+        name: sas-opendistro-sasadmin-secret
+      username:
+        key: username
+        name: sas-opendistro-sasadmin-secret
+    metricRelabelings:
     - action: replace
       sourceLabels:
       - node
       targetLabel: es_node
-    path: /metrics
-    port: http
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: (.+)
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_io_port]
+      action: replace
+      targetLabel: __address__
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sas_com_tls_enabled_ports]
+      action: replace
+      regex: all|.*http.*
+      targetLabel: __scheme__
+      replacement: https
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: replace
+      targetLabel: __scheme__
+      regex: (https?)
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/name: sas-opendistro-exporter
+      app.kubernetes.io/name: sas-opendistro

--- a/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
@@ -39,4 +39,4 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/name: sas-opendistro
+      opendistro.sas.com/service-name: sas-opendistro

--- a/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
@@ -11,6 +11,7 @@ spec:
       username:
         key: username
         name: sas-opendistro-sasadmin-secret
+    port: https
     metricRelabelings:
     - action: replace
       sourceLabels:

--- a/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-opensearch.yaml
@@ -1,0 +1,42 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sas-opensearch
+spec:
+  endpoints:
+  - basicAuth:
+      password:
+        key: password
+        name: sas-opendistro-sasadmin-secret
+      username:
+        key: username
+        name: sas-opendistro-sasadmin-secret
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - node
+      targetLabel: es_node
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: (.+)
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_io_port]
+      action: replace
+      targetLabel: __address__
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sas_com_tls_enabled_ports]
+      action: replace
+      regex: all|.*http.*
+      targetLabel: __scheme__
+      replacement: https
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: replace
+      targetLabel: __scheme__
+      regex: (https?)
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sas-opendistro


### PR DESCRIPTION
Modified the ServiceMonitor definition so it uses basicAuth to connect to the exporter endpoint & added relabelling so it gets the scheme, path etc from Opendistro's annotations 