### PR TITLE
Disable http2 for sas-arke servicemonitor

### DIFF
--- a/monitoring/monitors/viya/serviceMonitor-sas-arke.yaml
+++ b/monitoring/monitors/viya/serviceMonitor-sas-arke.yaml
@@ -11,6 +11,7 @@ spec:
   endpoints:
   - port: tcp
     path: /metrics
+    enableHttp2: false
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_label_sas_com_deployment]
       targetLabel: sas_deployment


### PR DESCRIPTION
Hi, apparently sas-arke does not support http2.0. We use https in an environment of a client and Prometheus cannot scrape the service without this setting.