### PR TITLE
Move modified HpaMaxedOut alert to kube-prometheus-stack helm chart

### DIFF
--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -320,15 +320,6 @@ for f in monitoring/rules/viya/rules-*.yaml; do
   kubectl apply -n $MON_NS -f $f
 done
 
-kubectl get prometheusrule -n $MON_NS v4m-kubernetes-apps 2>/dev/null
-if [ $? == 0 ]; then
-  log_verbose "Patching KubeHpaMaxedOut rule"
-  # Fixes the issue of false positives when max replicas == 1
-  kubectl patch prometheusrule --type='json' -n $MON_NS v4m-kubernetes-apps --patch "$(cat monitoring/kube-hpa-alert-patch.json)"
-else
-  log_debug "PrometheusRule $MON_NS/v4m-kubernetes-apps does not exist"
-fi
-
 # Elasticsearch Datasource for Grafana
 LOGGING_DATASOURCE="${LOGGING_DATASOURCE:-false}"
 if [ "$LOGGING_DATASOURCE" == "true" ]; then

--- a/monitoring/kube-hpa-alert-patch.json
+++ b/monitoring/kube-hpa-alert-patch.json
@@ -1,7 +1,0 @@
-[ 
-  {
-    "op" : "replace",
-    "path" : "/spec/groups/0/rules/14/expr",
-    "value" : "(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > 1"
-  }
-]

--- a/monitoring/values-prom-operator.yaml
+++ b/monitoring/values-prom-operator.yaml
@@ -12,6 +12,29 @@
 commonLabels:
   sas.com/monitoring-base: kube-viya-monitoring
 
+defaultRules:
+  disabled:
+    KubeHpaMaxedOut: true
+
+additionalPrometheusRulesMap:
+  sas-modified-default-rules:
+    groups:
+    - name: kubernetes-apps
+      rules:
+      - alert: KubeHpaMaxedOutMultiPod
+        annotations:
+          description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
+            has been running at max replicas for longer than 15 minutes.
+          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
+          summary: HPA is running at max replicas
+        expr: (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics",namespace=~".*"}
+          == kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics",namespace=~".*"})
+          and kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics",namespace=~".*"}
+          > 1
+        for: 15m
+        labels:
+          severity: warning
+
 # ===================
 # Prometheus Operator
 # ===================


### PR DESCRIPTION
Currently the HpaMaxedOut alert from the default rules set of the kube-prometheus-stack helm chart is deployed and then modified on the cluster. More information on the current situation can be found in PR #575.

This PR moves the change to the values-prom-operator.yaml file so that users can modify the default set of alerts. The Alert is renamed to reflect the modification and avoid issues with the reused name during upgrades.

Fixes #575.