### PR TITLE
Fix to support removal of --short option from kubectl version

### DIFF
--- a/bin/kube-include.sh
+++ b/bin/kube-include.sh
@@ -11,8 +11,8 @@ if [ ! "$(which kubectl)" ]; then
   exit 1
 fi
 
-KUBE_CLIENT_VER=$(kubectl version --short | grep 'Client Version' | awk '{print $3}' 2>/dev/null)
-KUBE_SERVER_VER=$(kubectl version --short | grep 'Server Version' | awk '{print $3}' 2>/dev/null)
+KUBE_CLIENT_VER=$(kubectl version --output=json | tr -d '\n' | sed -E 's/\s+/ /g' | sed -E 's/^\{.*"clientVersion":\s*\{([^\}]+)}.*/\1\n/' | sed -E 's/.*"gitVersion":\s+"([^\"]*)".*$/\1/')
+KUBE_SERVER_VER=$(kubectl version --output=json | tr -d '\n' | sed -E 's/\s+/ /g' | sed -E 's/^\{.*"serverVersion":\s*\{([^\}]+)}.*/\1\n/' | sed -E 's/.*"gitVersion":\s+"([^\"]*)".*$/\1/')
 
 # Client version allowed to be one minor version earlier than minimum server version
 if [[ $KUBE_CLIENT_VER =~ v1.2[0-9] ]]; then


### PR DESCRIPTION
kubectl version --short is no longer supported at 1.28. Switching to using --output=json and parsing this with tr and sed.