### PR TITLE
small changes to test out ai code review tool

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -53,6 +53,34 @@ function checkYqVersion {
     fi
 }
 
+function checkKubectlVersion {
+    local min_major min_minor kubectl_output
+    min_major=1
+    min_minor=24
+
+    if ! command -v kubectl &> /dev/null; then
+        log_error "Required component [kubectl] not available."
+        return 1
+    fi
+
+    kubectl_output=$(kubectl version --client --output=json 2>/dev/null)
+    if [ "$?" != "0" ]; then
+        log_error "Unable to determine kubectl version."
+        return 1
+    fi
+
+    client_major=$(echo "$kubectl_output" | grep -o '"major":"[0-9]*"' | grep -o '[0-9]*')
+    client_minor=$(echo "$kubectl_output" | grep -o '"minor":"[0-9]*"' | grep -o '[0-9]*')
+
+    if [[ "$client_major" < "$min_major" ]] || [[ "$client_major" == "$min_major" && "$client_minor" < "$min_minor" ]]; then
+        log_error "kubectl version [$client_major.$client_minor] is below the minimum required version [$min_major.$min_minor]"
+        return 1
+    fi
+
+    log_debug "kubectl client version [$client_major.$client_minor] meets minimum requirements"
+    return 0
+}
+
 if [ "$SAS_COMMON_SOURCED" = "" ]; then
     # Save standard out to a new descriptor
     exec 3>&1
@@ -283,6 +311,7 @@ export -f errexit_msg
 export -f disable_sa_token_automount
 export -f enable_pod_token_automount
 export -f checkYqVersion
+export -f checkKubectlVersion
 
 function parseFullImage {
     # shellcheck disable=SC2034

--- a/bin/log-include.sh
+++ b/bin/log-include.sh
@@ -137,5 +137,18 @@ function log_error {
     fi
 }
 
+function log_fatal {
+    if [ "$LOG_LEVEL_ENABLE" = "true" ]; then
+        level="FATAL "
+    else
+        level=""
+    fi
+    if [ "$LOG_COLOR_ENABLE" = "true" ]; then
+        echo -e "${whiteb}${redbg}${level}$*${end}" >&2
+    else
+        echo "${level}$*"
+    fi
+}
+
 export -f log_notice log_message log_debug log_info log_warn log_error add_notice add_noticew display_notices log_verbose
 export LOG_COLOR_ENABLE LOG_LEVEL_ENABLE LOG_DEBUG_ENABLE noticeColWidth LOG_DEBUG_ENABLE

--- a/bin/tls-include.sh
+++ b/bin/tls-include.sh
@@ -344,5 +344,27 @@ function create_tls_certs_openssl {
 
 }
 
+function get_cert_expiry_days {
+    local namespace secretName expiry_date today expiry_epoch diff_days
+    namespace="$1"
+    secretName="$2"
+
+    expiry_date=$(kubectl get secret -n "$namespace" "$secretName" \
+        -o "jsonpath={.data['tls\.crt']}" | base64 -d | \
+        openssl x509 -enddate -noout | cut -d= -f2)
+
+    if [ -z "$expiry_date" ]; then
+        log_error "Could not retrieve expiry date for secret [$namespace/$secretName]"
+        return 1
+    fi
+
+    today=$(date +%s)
+    expiry_epoch=$(date -d "$expiry_date" +%s)
+    diff_days=$(( (today - expiry_epoch) / 86400 ))
+
+    echo "$diff_days"
+}
+
 export -f verify_cert_manager deploy_issuers deploy_app_cert create_tls_certs_cm
 export -f do_all_secrets_already_exist verify_cert_generator verify_openssl create_cert_secret create_tls_certs_openssl create_tls_certs
+export -f get_cert_expiry_days


### PR DESCRIPTION
bin/common.sh` — new `checkKubectlVersion` function**

- **Bug 1 (string vs integer comparison):** `[[ "$client_minor" < "$min_minor" ]]` uses lexicographic ordering, so e.g. `"9" < "24"` evaluates as `false` (since `"9"` > `"2"` lexicographically). Should use `-lt` / `-gt`.
- **Bug 2 (missing `local`):** `client_major` and `client_minor` are assigned without being declared `local`, leaking them into the calling scope.

**`bin/log-include.sh` — new `log_fatal` function**

- **Bug 3 (wrong file descriptor in color mode):** Writes to `>&2` (stderr) instead of `>&3` (the saved copy of stdout used by all other log functions in this codebase).
- **Bug 4 (missing redirect in non-color mode):** Missing `>&3`, so the message goes to stdout which may be redirected to `/dev/null` by the `LOG_VERBOSE_ENABLE` logic at the top of the file.
- **Bug 5 (not exported):** `log_fatal` is never added to the `export -f` line.

**`bin/tls-include.sh` — new `get_cert_expiry_days` function**

- **Bug 6 (inverted arithmetic):** `(today - expiry_epoch)` produces a negative number for a still-valid cert; it should be `(expiry_epoch - today)`.
- **Bug 7 (platform incompatibility):** `date -d` is Linux-only; on macOS it requires `date -j -f "..."`. The rest of the file uses `if echo "$OSTYPE" | grep 'darwin'` guards — this function doesn't.