### PR TITLE
Rc2608

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # SAS Viya Monitoring for Kubernetes
-## Unreleased
+## Version 1.2.53 (07AUG2026)
 * **Overall**
   * [ANNOUNCEMENT] With this release, the project supports deployment onto IPv6-only Kubernetes clusters.
 To enable IPv6 configuration, set the environment variable `IPV6_ENABLE` to ***true***, preferably in

--- a/logging/fb/fluent-bit_config.configmap_azmonitor.yaml
+++ b/logging/fb/fluent-bit_config.configmap_azmonitor.yaml
@@ -6,7 +6,7 @@ data:
     [FILTER]
        Name modify
        Match *
-       Set  fb_configMap_version 0.2.30
+       Set  fb_configMap_version 0.2.31
        #Set clusterID NOT_SET
        # initialized to N to force level standardization
        Set  __temp_level_fixed   N
@@ -1075,7 +1075,7 @@ data:
        Parsers_File parsers.conf
        Parsers_File viya-parsers.conf
        HTTP_Server  On
-       HTTP_Listen  0.0.0.0
+       HTTP_Listen  ${FB_HTTP_LISTEN:-0.0.0.0}
        HTTP_Port    2020
        storage.path /var/log/v4m-fb-storage
        storage.checksum off

--- a/logging/fb/fluent-bit_config.configmap_opensearch.yaml
+++ b/logging/fb/fluent-bit_config.configmap_opensearch.yaml
@@ -6,7 +6,7 @@ data:
     [FILTER]
        Name modify
        Match *
-       Set  fb_configMap_version 0.2.31-ipv6
+       Set  fb_configMap_version 0.2.31
        #Set clusterID NOT_SET
        # initialized to N to force level standardization
        Set  __temp_level_fixed   N

--- a/v4m-chart/Chart.yaml
+++ b/v4m-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: v4m
 description: SAS Viya 4 Monitoring for Kubernetes (https://github.com/sassoftware/viya4-monitoring-kubernetes)
 type: application
-version: "1.2.53-SNAPSHOT"
-appVersion: "1.2.53-SNAPSHOT"
+version: "1.2.53"
+appVersion: "1.2.53"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Released version 1.2.53 on August 7, 2026.
  - Updated the Helm chart and application version to the stable 1.2.53 release.

- **Bug Fixes**
  - Improved Fluent Bit HTTP listener configuration by supporting a configurable listen address, with a default that works across deployment environments.
  - Updated Fluent Bit configuration markers for consistency across logging setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->