### PR TITLE
Upgrade Monitoring Components 2026.09

### DIFF
--- a/ARTIFACT_INVENTORY.md
+++ b/ARTIFACT_INVENTORY.md
@@ -21,16 +21,16 @@ registry/repository/image_name:version
 | Logging | initContainer (Fluent Bit, OpenSearch) | docker.io/library/busybox:latest |
 | Logging | [OpenSearch](https://github.com/opensearch-project/OpenSearch) | docker.io/opensearchproject/opensearch:3.6.0 |
 | Logging | [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards) | docker.io/opensearchproject/opensearch-dashboards:3.6.0 |
-| Metrics | [Alertmanager](https://github.com/prometheus/alertmanager) | quay.io/prometheus/alertmanager:v0.32.1 |
-| Metrics | [Grafana](https://github.com/grafana/grafana) | docker.io/grafana/grafana:13.0.1-security-01 |
+| Metrics | [Alertmanager](https://github.com/prometheus/alertmanager) | quay.io/prometheus/alertmanager:v0.33.1 |
+| Metrics | [Grafana](https://github.com/grafana/grafana) | docker.io/grafana/grafana:13.0.3 |
 | Metrics | [Admission Webhook](https://github.com/kubernetes/ingress-nginx) | ghcr.io/jkroepke/kube-webhook-certgen:1.8.2 |
 | Metrics | [Kube State Metrics](https://github.com/kubernetes/kube-state-metrics) | registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1 |
-| Metrics | [Node Exporter](https://github.com/prometheus/node_exporter) | quay.io/prometheus/node-exporter:v1.11.1-distroless |
-| Metrics | [Prometheus](https://github.com/prometheus/prometheus) | quay.io/prometheus/prometheus:v3.11.3-distroless |
-| Metrics | [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) | quay.io/prometheus-operator/prometheus-operator:v0.90.1 |
-| Metrics | [Configuration Reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader) | quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1 |
-| Metrics | [Prometheus Pushgateway](https://github.com/prometheus/pushgateway) | quay.io/prometheus/pushgateway:v1.11.2 |
-| Metrics | [Auto-load Sidecars](https://github.com/kiwigrid/k8s-sidecar) | quay.io/kiwigrid/k8s-sidecar:2.7.3 |
+| Metrics | [Node Exporter](https://github.com/prometheus/node_exporter) | quay.io/prometheus/node-exporter:v1.12.1-distroless |
+| Metrics | [Prometheus](https://github.com/prometheus/prometheus) | quay.io/prometheus/prometheus:v3.13.2-distroless |
+| Metrics | [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) | quay.io/prometheus-operator/prometheus-operator:v0.93.0 |
+| Metrics | [Configuration Reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader) | quay.io/prometheus-operator/prometheus-config-reloader:v0.93.0 |
+| Metrics | [Prometheus Pushgateway](https://github.com/prometheus/pushgateway) | quay.io/prometheus/pushgateway:v1.11.3 |
+| Metrics | [Auto-load Sidecars](https://github.com/kiwigrid/k8s-sidecar) | quay.io/kiwigrid/k8s-sidecar:2.10.1 |
 | Metrics | OpenShift OAUTH Proxy (Grafana, OpenShift only) | registry.redhat.io/openshift4/ose-oauth-proxy:latest |
 | Metrics | [Tempo](https://github.com/grafana/tempo) | docker.io/grafana/tempo:2.10.7 |
 
@@ -54,9 +54,9 @@ This table identifies the Helm charts used by SAS Viya Monitoring for Kubernetes
 | Logging | [Fluent Bit](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit)| fluent | fluent-bit | 0.57.7 | fluent/fluent-bit-0.57.7.tgz |
 | Logging | [OpenSearch](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch)| opensearch | opensearch | 3.6.0 | opensearch/opensearch-3.6.0.tgz |
 | Logging | [OpenSearch Dashboards](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch-dashboards)| opensearch | opensearch-dashboards | 3.6.0 | opensearch/opensearch-dashboards-3.6.0.tgz |
-| Metrics | [Grafana (on OpenShift)](https://github.com/grafana-community/helm-charts/tree/main/charts/grafana)| grafana-community | grafana | 12.3.3 | grafana-community/grafana-12.3.3.tgz |
-| Metrics | [Kube Prometheus Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)| prometheus-community | kube-prometheus-stack | 85.1.3 | prometheus-community/kube-prometheus-stack-85.1.3.tgz |
-| Metrics | [Prometheus Pushgateway](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-pushgateway)| prometheus-community | prometheus-pushgateway | 3.6.0 | prometheus-community/prometheus-pushgateway-3.6.0.tgz |
+| Metrics | [Grafana (on OpenShift)](https://github.com/grafana-community/helm-charts/tree/main/charts/grafana)| grafana-community | grafana | 12.10.4 | grafana-community/grafana-12.10.4.tgz |
+| Metrics | [Kube Prometheus Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)| prometheus-community | kube-prometheus-stack | 88.2.0 | prometheus-community/kube-prometheus-stack-88.2.0.tgz |
+| Metrics | [Prometheus Pushgateway](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-pushgateway)| prometheus-community | prometheus-pushgateway | 3.7.0 | prometheus-community/prometheus-pushgateway-3.7.0.tgz |
 | Metrics | [Tempo](https://github.com/grafana-community/helm-charts/tree/main/charts/tempo)| grafana-community | tempo | 2.2.3 | grafana-community/tempo-2.2.3.tgz |
 
 ## Table 4. Miscellaneous Component Version Information
@@ -64,4 +64,4 @@ This table provides version information for some miscellaneous components deploy
 
 | Component | Version | Project Repository | Notes |
 |--|--|--|--|
-| OpenSearch Datasource Plugin (Grafana) | 2.33.1 | https://github.com/grafana/opensearch-datasource/releases |Allows Grafana to surface log messages stored in OpenSearch |
+| OpenSearch Datasource Plugin (Grafana) | 2.34.3 | https://github.com/grafana/opensearch-datasource/releases |Allows Grafana to surface log messages stored in OpenSearch |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # SAS Viya Monitoring for Kubernetes
 ## Unreleased
 * **Metrics**
+  * [UPGRADE] Kube-Prometheus Stack Helm chart has been upgraded from 85.1.3 to 88.2.0
+  * [UPGRADE] Grafana Helm Chart (for OpenShift deployments) has been upgraded from 12.3.3 to 12.10.4
+  * [UPGRADE] Alertmanager has been upgraded from 0.32.1 to 0.33.1
+  * [UPGRADE] The config-reloader has been upgraded from 0.90.1 to 0.93.0
+  * [UPGRADE] Grafana has been upgraded from 13.0.1 to 13.0.3
+  * [UPGRADE] The k8s-sidecar has been upgraded from 2.7.3 to 2.10.1
+  * [UPGRADE] Node-Exporter has been upgraded from 1.11.1 to 1.12.1
+  * [UPGRADE] Prometheus has been upgraded from 3.11.3 to 3.13.2
+  * [UPGRADE] Prometheus Operator has been upgraded from 0.90.1 to 0.93.0
+  * [UPGRADE] Prometheus Pushgateway Helm chart has been upgraded from 3.6.0 to 3.7.0
+  * [UPGRADE] Prometheus Pushgateway has been upgraded from 1.11.2 to 1.11.3
+  * [UPGRADE] OpenSearch Data Source Plugin for Grafana upgraded from 2.33.1 to 2.34.3
   * [FIX] Corrected an issue which prevented metrics from being available in Grafana when path-based
 routing using Contour was configured automatically.  (Fixes #882)
   * [FIX] Corrected Alertmanager URL when `ALERTMANAGER_PATH` is set and path-based routing using Contour

--- a/component_versions.env
+++ b/component_versions.env
@@ -37,31 +37,31 @@ OSD_FULL_IMAGE="docker.io/opensearchproject/opensearch-dashboards:3.6.0"
 #Grafana (when deployed on OpenShift)
 OPENSHIFT_GRAFANA_CHART_REPO=grafana-community
 OPENSHIFT_GRAFANA_CHART_NAME=grafana
-OPENSHIFT_GRAFANA_CHART_VERSION=12.3.3
+OPENSHIFT_GRAFANA_CHART_VERSION=12.10.4
 OPENSHIFT_OAUTHPROXY_FULL_IMAGE="registry.redhat.io/openshift4/ose-oauth-proxy:latest"
 
 #Grafana (everywhere)
-GRAFANA_FULL_IMAGE="docker.io/grafana/grafana:13.0.1-security-01"
-GRAFANA_SIDECAR_FULL_IMAGE="quay.io/kiwigrid/k8s-sidecar:2.7.3"
-GRAFANA_DATASOURCE_PLUGIN_VERSION="2.33.1"
+GRAFANA_FULL_IMAGE="docker.io/grafana/grafana:13.0.3"
+GRAFANA_SIDECAR_FULL_IMAGE="quay.io/kiwigrid/k8s-sidecar:2.10.1"
+GRAFANA_DATASOURCE_PLUGIN_VERSION="2.34.3"
 
 #Kube-Prometheus Stack
 KUBE_PROM_STACK_CHART_REPO=prometheus-community
 KUBE_PROM_STACK_CHART_NAME=kube-prometheus-stack
-KUBE_PROM_STACK_CHART_VERSION=85.1.3
-ALERTMANAGER_FULL_IMAGE="quay.io/prometheus/alertmanager:v0.32.1"
+KUBE_PROM_STACK_CHART_VERSION=88.2.0
+ALERTMANAGER_FULL_IMAGE="quay.io/prometheus/alertmanager:v0.33.1"
 ADMWEBHOOK_FULL_IMAGE="ghcr.io/jkroepke/kube-webhook-certgen:1.8.2"
 KSM_FULL_IMAGE="registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1"
-NODEXPORT_FULL_IMAGE="quay.io/prometheus/node-exporter:v1.11.1-distroless"
-PROMETHEUS_FULL_IMAGE="quay.io/prometheus/prometheus:v3.11.3-distroless"
-PROMOP_FULL_IMAGE="quay.io/prometheus-operator/prometheus-operator:v0.90.1"
-CONFIGRELOAD_FULL_IMAGE="quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1"
+NODEXPORT_FULL_IMAGE="quay.io/prometheus/node-exporter:v1.12.1-distroless"
+PROMETHEUS_FULL_IMAGE="quay.io/prometheus/prometheus:v3.13.2-distroless"
+PROMOP_FULL_IMAGE="quay.io/prometheus-operator/prometheus-operator:v0.93.0"
+CONFIGRELOAD_FULL_IMAGE="quay.io/prometheus-operator/prometheus-config-reloader:v0.93.0"
 
 #Pushgateway
 PUSHGATEWAY_CHART_REPO=prometheus-community
 PUSHGATEWAY_CHART_NAME=prometheus-pushgateway
-PUSHGATEWAY_CHART_VERSION=3.6.0
-PUSHGATEWAY_FULL_IMAGE="quay.io/prometheus/pushgateway:v1.11.2"
+PUSHGATEWAY_CHART_VERSION=3.7.0
+PUSHGATEWAY_FULL_IMAGE="quay.io/prometheus/pushgateway:v1.11.3"
 
 #Prometheus Operator CRD
 ##NOTE: PROM_OPERATOR_CRD_VERSION is now automatically


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the monitoring stack to newer versions of Grafana, Prometheus, Alertmanager, Node Exporter, Prometheus Operator, Pushgateway, and related components.
  * Updated the Kube-Prometheus Stack and Grafana Helm chart versions.
  * Updated the Grafana OpenSearch data source plugin.
  * Refreshed container images and supporting sidecars for improved compatibility and access to the latest component updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->