### PR TITLE
Data Leakage Fix for KSM and Node Exporter using Kube RBAC Proxy and Network Policy

### DIFF
--- a/.github/workflows/build-artifact/ARTIFACT_INVENTORY.template
+++ b/.github/workflows/build-artifact/ARTIFACT_INVENTORY.template
@@ -26,6 +26,7 @@ registry/repository/image_name:version
 | Metrics | [Admission Webhook](https://github.com/kubernetes/ingress-nginx) | __ADMWEBHOOK_FULL_IMAGE__ |
 | Metrics | [Kube State Metrics](https://github.com/kubernetes/kube-state-metrics) | __KSM_FULL_IMAGE__ |
 | Metrics | [Node Exporter](https://github.com/prometheus/node_exporter) | __NODEXPORT_FULL_IMAGE__ |
+| Metrics | [Kube RBAC Proxy](https://github.com/kube-rbac-proxy/kube-rbac-proxy) | __RBAC_PROXY_FULL_IMAGE__ |
 | Metrics | [Prometheus](https://github.com/prometheus/prometheus) | __PROMETHEUS_FULL_IMAGE__ |
 | Metrics | [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) | __PROMOP_FULL_IMAGE__ |
 | Metrics | [Configuration Reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader) | __CONFIGRELOAD_FULL_IMAGE__ |

--- a/.github/workflows/build-artifact/generate_inventory.sh
+++ b/.github/workflows/build-artifact/generate_inventory.sh
@@ -9,7 +9,9 @@
 
 V4M_BUILD_REPO=${V4M_BUILD_REPO:-"../v4m-build"}
 
+# shellcheck disable=SC2034 # used by bin/common.sh after it is sourced below
 CHECK_HELM=false
+# shellcheck disable=SC2034 # used by bin/common.sh after it is sourced below
 CHECK_KUBERNETES=false
 
 source bin/common.sh
@@ -21,18 +23,18 @@ cp "$template" "$file"
 
 function buildHelmArchiveFilename {
 
-   local prefix repo name version format chart_archive_filename
+    local prefix repo name version format chart_archive_filename
 
-   prefix=$1
-   repo="${prefix}_CHART_REPO"
-   name="${prefix}_CHART_NAME"
-   version="${prefix}_CHART_VERSION"
-   format="tgz"
-   chart_archive_filename="${!repo}\/${!name}-${!version}.$format"
-   v4m_replace "__${prefix}_CHART_REPO__" "${!repo}" "$file"
-   v4m_replace "__${prefix}_CHART_NAME__" "${!name}" "$file"
-   v4m_replace "__${prefix}_CHART_VERSION__" "${!version}" "$file"
-   v4m_replace "__${prefix}_CHART_ARCHIVE__" "$chart_archive_filename" "$file"
+    prefix=$1
+    repo="${prefix}_CHART_REPO"
+    name="${prefix}_CHART_NAME"
+    version="${prefix}_CHART_VERSION"
+    format="tgz"
+    chart_archive_filename="${!repo}\/${!name}-${!version}.$format"
+    v4m_replace "__${prefix}_CHART_REPO__" "${!repo}" "$file"
+    v4m_replace "__${prefix}_CHART_NAME__" "${!name}" "$file"
+    v4m_replace "__${prefix}_CHART_VERSION__" "${!version}" "$file"
+    v4m_replace "__${prefix}_CHART_ARCHIVE__" "$chart_archive_filename" "$file"
 
 }
 
@@ -47,7 +49,6 @@ buildHelmArchiveFilename "OPENSHIFT_GRAFANA"
 buildHelmArchiveFilename "KUBE_PROM_STACK"
 buildHelmArchiveFilename "PUSHGATEWAY"
 buildHelmArchiveFilename "TEMPO"
-
 
 ##
 ## Container Images (Table #1)
@@ -69,6 +70,9 @@ v4m_replace "__KSM_FULL_IMAGE__" "$FULL_IMAGE_ESCAPED" "$file"
 
 parseFullImage "$NODEXPORT_FULL_IMAGE"
 v4m_replace "__NODEXPORT_FULL_IMAGE__" "$FULL_IMAGE_ESCAPED" "$file"
+
+parseFullImage "$RBAC_PROXY_FULL_IMAGE"
+v4m_replace "__RBAC_PROXY_FULL_IMAGE__" "$FULL_IMAGE_ESCAPED" "$file"
 
 parseFullImage "$PROMETHEUS_FULL_IMAGE"
 v4m_replace "__PROMETHEUS_FULL_IMAGE__" "$FULL_IMAGE_ESCAPED" "$file"
@@ -106,6 +110,6 @@ v4m_replace "__PUSHGATEWAY_FULL_IMAGE__" "$FULL_IMAGE_ESCAPED" "$file"
 ##
 ## Misc components (Table #4)
 ##
-v4m_replace "__GRAFANA_DATASOURCE_PLUGIN_VERSION__" "$GRAFANA_DATASOURCE_PLUGIN_VERSION" "$file" 
+v4m_replace "__GRAFANA_DATASOURCE_PLUGIN_VERSION__" "$GRAFANA_DATASOURCE_PLUGIN_VERSION" "$file"
 
 log_notice "Be sure to review the generated file [$file] prior to adding/committing it to the repo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # SAS Viya Monitoring for Kubernetes
+## Unreleased
+* **Metrics**
+  * [SECURITY] Kube State Metrics (KSM) and Node Exporter previously exposed cluster-wide resource state
+and infrastructure metrics -- including pod labels used to identify per-user SAS job activity -- over
+unauthenticated, unencrypted HTTP endpoints reachable by any pod in the cluster. Both are now fronted by
+a `kube-rbac-proxy` sidecar enforcing Kubernetes RBAC and bound to localhost only; Prometheus scrapes
+them using its existing ServiceAccount token, with no certificate management required. This is
+controlled by the new `RBAC_PROXY_ENABLE` environment variable (default `true`), which is independent
+of `TLS_ENABLE`. `kube-rbac-proxy` is also the only source of transport encryption for both targets;
+setting `RBAC_PROXY_ENABLE=false` serves them over plain, unauthenticated HTTP regardless of
+`TLS_ENABLE`. Node Exporter previously supported its own native TLS independent of RBAC/auth; that
+capability has been retired in favor of `kube-rbac-proxy`.
+
 ## Version 1.2.54 (04SEP2026)
 * **Overall**
   * [CHORE] Refactor Helm Chart version checking/reporting
@@ -22,16 +35,6 @@ is configured automatically
   * [FIX] The `v4m-logging-root-proxy` HTTPProxy resource is only created in appropriate scenarios
 (i.e. auto-generated path-based routing using Contour) and any existing instance of this resource
 is deleted if found in other deployment scenarios (where it is not needed)
-  * [SECURITY] Kube State Metrics (KSM) and Node Exporter previously exposed cluster-wide resource state
-and infrastructure metrics -- including pod labels used to identify per-user SAS job activity -- over
-unauthenticated, unencrypted HTTP endpoints reachable by any pod in the cluster. Both are now fronted by
-a `kube-rbac-proxy` sidecar enforcing Kubernetes RBAC and bound to localhost only; Prometheus scrapes
-them using its existing ServiceAccount token, with no certificate management required. This is
-controlled by the new `RBAC_PROXY_ENABLE` environment variable (default `true`), which is independent
-of `TLS_ENABLE`. `kube-rbac-proxy` is also the only source of transport encryption for both targets;
-setting `RBAC_PROXY_ENABLE=false` serves them over plain, unauthenticated HTTP regardless of
-`TLS_ENABLE`. Node Exporter previously supported its own native TLS independent of RBAC/auth; that
-capability has been retired in favor of `kube-rbac-proxy`.
 ## Version 1.2.53 (07AUG2026)
 * **Overall**
   * [ANNOUNCEMENT] With this release, the project supports deployment onto IPv6-only Kubernetes clusters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,16 @@ is configured automatically
   * [FIX] The `v4m-logging-root-proxy` HTTPProxy resource is only created in appropriate scenarios
 (i.e. auto-generated path-based routing using Contour) and any existing instance of this resource
 is deleted if found in other deployment scenarios (where it is not needed)
-
+  * [SECURITY] Kube State Metrics (KSM) and Node Exporter previously exposed cluster-wide resource state
+and infrastructure metrics -- including pod labels used to identify per-user SAS job activity -- over
+unauthenticated, unencrypted HTTP endpoints reachable by any pod in the cluster. Both are now fronted by
+a `kube-rbac-proxy` sidecar enforcing Kubernetes RBAC and bound to localhost only; Prometheus scrapes
+them using its existing ServiceAccount token, with no certificate management required. This is
+controlled by the new `RBAC_PROXY_ENABLE` environment variable (default `true`), which is independent
+of `TLS_ENABLE`. `kube-rbac-proxy` is also the only source of transport encryption for both targets;
+setting `RBAC_PROXY_ENABLE=false` serves them over plain, unauthenticated HTTP regardless of
+`TLS_ENABLE`. Node Exporter previously supported its own native TLS independent of RBAC/auth; that
+capability has been retired in favor of `kube-rbac-proxy`.
 ## Version 1.2.53 (07AUG2026)
 * **Overall**
   * [ANNOUNCEMENT] With this release, the project supports deployment onto IPv6-only Kubernetes clusters.

--- a/component_versions.env
+++ b/component_versions.env
@@ -52,6 +52,7 @@ KUBE_PROM_STACK_CHART_VERSION=88.2.0
 ALERTMANAGER_FULL_IMAGE="quay.io/prometheus/alertmanager:v0.33.1"
 ADMWEBHOOK_FULL_IMAGE="ghcr.io/jkroepke/kube-webhook-certgen:1.8.2"
 KSM_FULL_IMAGE="registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1"
+RBAC_PROXY_FULL_IMAGE="quay.io/brancz/kube-rbac-proxy:v0.22.1"
 NODEXPORT_FULL_IMAGE="quay.io/prometheus/node-exporter:v1.12.1-distroless"
 PROMETHEUS_FULL_IMAGE="quay.io/prometheus/prometheus:v3.13.2-distroless"
 PROMOP_FULL_IMAGE="quay.io/prometheus-operator/prometheus-operator:v0.93.0"

--- a/monitoring/bin/common.sh
+++ b/monitoring/bin/common.sh
@@ -20,6 +20,7 @@ if [ "$SAS_MONITORING_COMMON_SOURCED" = "" ]; then
 
     export MON_NS="${MON_NS:-monitoring}"
     export TLS_ENABLE="${MON_TLS_ENABLE:-${TLS_ENABLE:-true}}"
+    export RBAC_PROXY_ENABLE="${RBAC_PROXY_ENABLE:-true}"
 
     if [ "$AIRGAP_DEPLOYMENT" == "true" ]; then
 

--- a/monitoring/bin/deploy_monitoring_cluster.sh
+++ b/monitoring/bin/deploy_monitoring_cluster.sh
@@ -134,6 +134,7 @@ fi
 generateImageKeysFile "$ALERTMANAGER_FULL_IMAGE" "$imageKeysFile" "ALERTMANAGER_"
 generateImageKeysFile "$ADMWEBHOOK_FULL_IMAGE" "$imageKeysFile" "ADMWEBHOOK_"
 generateImageKeysFile "$KSM_FULL_IMAGE" "$imageKeysFile" "KSM_"
+generateImageKeysFile "$RBAC_PROXY_FULL_IMAGE" "$imageKeysFile" "RBAC_PROXY_"
 generateImageKeysFile "$NODEXPORT_FULL_IMAGE" "$imageKeysFile" "NODEXPORT_"
 generateImageKeysFile "$PROMETHEUS_FULL_IMAGE" "$imageKeysFile" "PROMETHEUS_"
 generateImageKeysFile "$CONFIGRELOAD_FULL_IMAGE" "$imageKeysFile" "CONFIGRELOAD_"
@@ -221,13 +222,23 @@ if [ "$TLS_ENABLE" == "true" ]; then
     kubectl delete cm -n "$MON_NS" --ignore-not-found grafana-datasource-prom-https
     kubectl create cm -n "$MON_NS" grafana-datasource-prom-https --from-file "monitoring/tls/$grafanaDS"
     kubectl label cm -n "$MON_NS" grafana-datasource-prom-https grafana_datasource=1 sas.com/monitoring-base=kube-viya-monitoring
+fi
 
-    # node-exporter TLS
-    log_verbose "Enabling Prometheus node-exporter for TLS"
-    kubectl delete cm -n "$MON_NS" node-exporter-tls-web-config --ignore-not-found
-    sleep 1
-    kubectl create cm -n "$MON_NS" node-exporter-tls-web-config --from-file monitoring/tls/node-exporter-web.yaml
-    kubectl label cm -n "$MON_NS" node-exporter-tls-web-config sas.com/monitoring-base=kube-viya-monitoring
+# Optional RBAC-proxy protection for metrics-scraping targets (KSM, Node
+# Exporter). Independent of TLS_ENABLE -- see
+# monitoring/values-prom-operator-rbac-proxy.yaml for why.
+#
+# NOTE: kube-rbac-proxy is also the *only* source of transport encryption for
+# these two targets -- unlike Prometheus/Alertmanager/Grafana, Node Exporter
+# has no other supported way to serve TLS, and KSM never had one. Setting
+# RBAC_PROXY_ENABLE=false means both targets fall back to plain, unauthenticated
+# HTTP regardless of TLS_ENABLE.
+rbacProxyValuesFile=$TMP_DIR/empty.yaml
+if [ "$RBAC_PROXY_ENABLE" == "true" ]; then
+    rbacProxyValuesFile=monitoring/values-prom-operator-rbac-proxy.yaml
+    log_debug "Including RBAC-proxy response file $rbacProxyValuesFile"
+else
+    log_warn "RBAC_PROXY_ENABLE is false; KSM and Node Exporter will be served over plain, unauthenticated HTTP, even if TLS_ENABLE=true -- kube-rbac-proxy is their only source of both authentication and transport encryption."
 fi
 
 AUTOGENERATE_INGRESS="${AUTOGENERATE_INGRESS:-false}"
@@ -524,6 +535,58 @@ else
         --dry-run=client -o yaml | kubectl apply -f -
 fi
 
+ksmProbePatchPid=""
+if [ "$RBAC_PROXY_ENABLE" == "true" ]; then
+    # Work around an upstream kube-state-metrics chart bug: when
+    # kubeRBACProxy.enabled=true, the kube-state-metrics container's own
+    # liveness/readiness probes reference named ports ("http"/"metrics") that
+    # only exist on the kube-rbac-proxy sidecar, not on that container itself,
+    # so the pod never becomes Ready and the rollout below times out.
+    # See: https://github.com/prometheus-community/helm-charts/issues/6164
+    # Race the atomic rollout wait below: repoint both probes at the
+    # rbac-proxy's numeric port (8080), which proxies /livez unauthenticated
+    # (--ignore-paths=/livez,/readyz) through to kube-state-metrics's main
+    # metrics port. /readyz is only served on the telemetry port, which isn't
+    # reachable through this proxy when selfMonitor is disabled (our
+    # default), so both probes use /livez.
+    #
+    # On upgrades, wait for the Deployment's generation to change from its
+    # pre-Helm baseline before patching, so we patch after Helm writes the
+    # new pod template instead of racing ahead of it.
+    ksmDeployment="$promName-kube-state-metrics"
+    ksmBaselineGeneration=$(kubectl -n "$MON_NS" get deployment "$ksmDeployment" -o jsonpath='{.metadata.generation}' 2> /dev/null) || true
+    (
+        ksmPatched=false
+        for _ in $(seq 1 120); do
+            ksmCurrentGeneration=$(kubectl -n "$MON_NS" get deployment "$ksmDeployment" -o jsonpath='{.metadata.generation}' 2> /dev/null) || true
+            if [ -n "$ksmCurrentGeneration" ] && [ "$ksmCurrentGeneration" != "$ksmBaselineGeneration" ]; then
+                if kubectl -n "$MON_NS" patch deployment "$ksmDeployment" --patch '
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-state-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+' > /dev/null 2>&1; then
+                    ksmPatched=true
+                    break
+                fi
+            fi
+            sleep 1
+        done
+        [ "$ksmPatched" == "true" ]
+    ) &
+    ksmProbePatchPid=$!
+fi
+
+helmExitCode=0
 # shellcheck disable=SC2086
 helm $helmDebug upgrade --install "$promRelease" \
     $helm4opts \
@@ -533,6 +596,7 @@ helm $helmDebug upgrade --install "$promRelease" \
     -f "$istioValuesFile" \
     -f "$tlsValuesFile" \
     -f "$tlsPromAlertingEndpointFile" \
+    -f "$rbacProxyValuesFile" \
     -f "$nodePortValuesFile" \
     -f "$wnpValuesFile" \
     -f "$autogeneratedYAMLFile" \
@@ -547,7 +611,20 @@ helm $helmDebug upgrade --install "$promRelease" \
     --set grafana.adminPassword="$grafanaPwd" \
     --set prometheus.prometheusSpec.alertingEndpoints[0].namespace="$MON_NS" \
     $versionstring \
-    "$chart2install"
+    "$chart2install" || helmExitCode=$?
+
+# Stop and wait for the probe patcher before doing anything else, regardless
+# of whether Helm succeeded, so it can never race ahead and patch a
+# Deployment that --atomic has already rolled back after a failure.
+if [ -n "$ksmProbePatchPid" ]; then
+    kill "$ksmProbePatchPid" 2> /dev/null || true
+    wait "$ksmProbePatchPid" 2> /dev/null || true
+fi
+
+if [ "$helmExitCode" -ne 0 ]; then
+    log_error "Helm install/upgrade of [$promRelease] failed with exit code [$helmExitCode]"
+    exit "$helmExitCode"
+fi
 
 sleep 2
 

--- a/monitoring/prom-operator_container_image.template
+++ b/monitoring/prom-operator_container_image.template
@@ -87,6 +87,12 @@ kube-state-metrics:
     tag: __KSM_IMAGE_TAG__
     pullPolicy: __KSM_IMAGE_PULL_POLICY__
 ####  imagePullSecrets: __KSM_IMAGE_PULL_SECRETS__
+  kubeRBACProxy:
+    image:
+      registry: __RBAC_PROXY_IMAGE_REGISTRY__
+      repository: __RBAC_PROXY_IMAGE_REPO_2LEVEL__
+      tag: __RBAC_PROXY_IMAGE_TAG__
+      pullPolicy: __RBAC_PROXY_IMAGE_PULL_POLICY__
 
 ##Node Exporter
 prometheus-node-exporter:
@@ -104,6 +110,12 @@ prometheus-node-exporter:
     tag: __NODEXPORT_IMAGE_TAG__
     pullPolicy: __NODEXPORT_IMAGE_PULL_POLICY__
 ####  imagePullSecrets: __IMAGE_PULL_SECRETS__
+  kubeRBACProxy:
+    image:
+      registry: __RBAC_PROXY_IMAGE_REGISTRY__
+      repository: __RBAC_PROXY_IMAGE_REPO_2LEVEL__
+      tag: __RBAC_PROXY_IMAGE_TAG__
+      pullPolicy: __RBAC_PROXY_IMAGE_PULL_POLICY__
 
 ##Prometheus
 prometheus:

--- a/monitoring/tls/values-prom-operator-tls.yaml
+++ b/monitoring/tls/values-prom-operator-tls.yaml
@@ -38,20 +38,6 @@ alertmanager:
     tlsConfig:
       insecureSkipVerify: true
 
-prometheus-node-exporter:
-  extraArgs:
-    - "--web.config.file=/opt/node-exporter/node-exporter-web.yaml"
-  configmaps:
-    - name: node-exporter-tls-web-config
-      mountPath: /opt/node-exporter
-
-# node-exporter helm chart does not yet support HTTPS
-# node-exporter:
-#   sidecarVolumeMount:
-#   - name: tls-secret
-#     mountPath: /cert
-#     readOnly: true
-
 grafana:
   readinessProbe:
     httpGet:

--- a/monitoring/values-prom-operator-rbac-proxy.yaml
+++ b/monitoring/values-prom-operator-rbac-proxy.yaml
@@ -1,0 +1,47 @@
+# Applied only when RBAC_PROXY_ENABLE=true (the default).
+#
+# This is independent of TLS_ENABLE: TLS_ENABLE controls whether Prometheus,
+# Alertmanager, and Grafana serve their own web endpoints over TLS using
+# managed certificates. This file controls whether metrics-scraping targets
+# (KSM, Node Exporter) require an authenticated caller. kube-rbac-proxy does
+# terminate its own TLS, but with a self-signed cert Prometheus is told to
+# skip verification on (insecureSkipVerify: true) -- the actual security
+# control here is the RBAC/bearer-token check, not the TLS encryption.
+
+# https://github.com/kubernetes/kube-state-metrics
+kube-state-metrics:
+  # KSM binds to localhost only; kube-rbac-proxy is deployed as a sidecar and
+  # is the sole externally-reachable entry point, enforcing Kubernetes RBAC
+  # (SubjectAccessReview) via a bearer token before forwarding to KSM.
+  # See: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics#exposing-the-kube-state-metrics-service-using-the-kube-rbac-proxy
+  kubeRBACProxy:
+    enabled: true
+
+  prometheus:
+    monitor:
+      # kube-rbac-proxy terminates TLS with a self-signed cert (no cert
+      # management required) and authenticates the scrape using Prometheus's
+      # own ServiceAccount token.
+      http:
+        scheme: https
+        tlsConfig:
+          insecureSkipVerify: true
+        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+prometheus-node-exporter:
+  # Node Exporter binds to localhost only; kube-rbac-proxy is deployed as a
+  # sidecar and is the sole externally-reachable entry point, enforcing
+  # Kubernetes RBAC (SubjectAccessReview) via a bearer token before
+  # forwarding to Node Exporter. Same pattern used for kube-state-metrics.
+  # See: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter#tls-and-client-certificate-authentication
+  kubeRBACProxy:
+    enabled: true
+  prometheus:
+    monitor:
+      # kube-rbac-proxy terminates TLS with a self-signed cert (no cert
+      # management required) and authenticates the scrape using Prometheus's
+      # own ServiceAccount token.
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/monitoring/values-prom-operator.yaml
+++ b/monitoring/values-prom-operator.yaml
@@ -81,6 +81,10 @@ kube-state-metrics:
   extraArgs:
     - --metric-labels-allowlist=nodes=[*],namespaces=[*],pods=[*],deployments=[*],statefulsets=[*],daemonsets=[*],jobs=[*]
 
+  # NOTE: kube-rbac-proxy sidecar config lives in
+  #       monitoring/values-prom-operator-rbac-proxy.yaml, applied when
+  #       RBAC_PROXY_ENABLE=true (the default). See that file for details.
+
   # Available collectors for kube-state-metrics.
   # By default, all available resources are enabled, comment out to disable.
   collectors:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added Kubernetes RBAC proxy sidecars for Prometheus, Kube State Metrics, and Node Exporter.
  - Metrics scraping now uses authenticated HTTPS connections through the proxies.
  - Retired Node Exporter’s native TLS configuration.

- **Configuration**
  - Added an environment setting to enable or disable RBAC proxies, enabled by default.
  - Added deployment settings and artifact inventory support for the proxy image.
  - Grafana Prometheus queries now use authenticated bearer tokens when proxies are enabled.

- **Behavior Changes**
  - Removed NetworkPolicy-based access restrictions for Kube State Metrics and Node Exporter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->