### PR TITLE
[FIX] Only delete HTTPProxy resource if CRD exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # SAS Viya Monitoring for Kubernetes
+## Unreleased
+* **Logging**
+  * [FIX] Only attempt to delete an unneeded `v4m-logging-root-proxy` HTTPProxy resource if the
+CRD (httpproxies.projectcontour.io) is installed
+
 ## Version 1.2.54 (04SEP2026)
 * **Overall**
   * [CHORE] Refactor Helm Chart version checking/reporting
@@ -19,6 +24,7 @@
 routing using Contour was configured automatically.  (Fixes #882)
   * [FIX] Corrected Alertmanager URL when `ALERTMANAGER_PATH` is set and path-based routing using Contour
 is configured automatically
+* **Logging**
   * [FIX] The `v4m-logging-root-proxy` HTTPProxy resource is only created in appropriate scenarios
 (i.e. auto-generated path-based routing using Contour) and any existing instance of this resource
 is deleted if found in other deployment scenarios (where it is not needed)

--- a/logging/bin/deploy_logging.sh
+++ b/logging/bin/deploy_logging.sh
@@ -61,7 +61,6 @@ if [ "$AUTOGENERATE_INGRESS" == "true" ]; then
     else
         if kubectl get crd httpproxies.projectcontour.io -o name > /dev/null 2>&1; then
 
-
             log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists"
             kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
         fi

--- a/logging/bin/deploy_logging.sh
+++ b/logging/bin/deploy_logging.sh
@@ -63,8 +63,10 @@ if [ "$AUTOGENERATE_INGRESS" == "true" ]; then
         kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
     fi
 else
-    log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists (AUTOGENERATE_INGRESS=[$AUTOGENERATE_INGRESS])"
-    kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
+    if kubectl get crd httpproxies.projectcontour.io --ignore-not-found -o name > /dev/null; then
+        log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists (AUTOGENERATE_INGRESS=[$AUTOGENERATE_INGRESS])"
+        kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
+    fi
 fi
 
 ##################################

--- a/logging/bin/deploy_logging.sh
+++ b/logging/bin/deploy_logging.sh
@@ -59,8 +59,11 @@ if [ "$AUTOGENERATE_INGRESS" == "true" ]; then
     if [ "$INGRESS_CREATE_ROOT_PROXY" == "true" ] && [ "$INGRESS_TYPE" == "contour" ]; then
         create_root_httpproxy logging "$LOG_NS"
     else
-        log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists"
-        kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
+        if kubectl get crd httpproxies.projectcontour.io --ignore-not-found -o name > /dev/null; then
+
+            log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists"
+            kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
+        fi
     fi
 else
     if kubectl get crd httpproxies.projectcontour.io --ignore-not-found -o name > /dev/null; then

--- a/logging/bin/deploy_logging.sh
+++ b/logging/bin/deploy_logging.sh
@@ -59,14 +59,15 @@ if [ "$AUTOGENERATE_INGRESS" == "true" ]; then
     if [ "$INGRESS_CREATE_ROOT_PROXY" == "true" ] && [ "$INGRESS_TYPE" == "contour" ]; then
         create_root_httpproxy logging "$LOG_NS"
     else
-        if kubectl get crd httpproxies.projectcontour.io --ignore-not-found -o name > /dev/null; then
+        if kubectl get crd httpproxies.projectcontour.io -o name > /dev/null 2>&1; then
+
 
             log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists"
             kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
         fi
     fi
 else
-    if kubectl get crd httpproxies.projectcontour.io --ignore-not-found -o name > /dev/null; then
+    if kubectl get crd httpproxies.projectcontour.io -o name > /dev/null 2>&1; then
         log_debug "Deleting [httpproxy/v4m-logging-root-proxy] if it exists (AUTOGENERATE_INGRESS=[$AUTOGENERATE_INGRESS])"
         kubectl -n "$LOG_NS" delete httpproxy v4m-logging-root-proxy --ignore-not-found
     fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging cleanup to avoid attempting to remove the root HTTPProxy when the required Contour resource definition is unavailable.
  * Root HTTPProxy creation now occurs only when ingress autogeneration, root-proxy creation, and Contour ingress are enabled.
  * Applied safer handling across supported ingress configuration scenarios.

* **Documentation**
  * Updated the changelog with details of the logging cleanup fix and root HTTPProxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->